### PR TITLE
Fixing poetry installation process in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,11 @@ Poetry - это инструмент для управления зависим�
 
 Для UNIX систем вводим в консоль следующую команду
 
-> *curl
--sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
-| python -*
+> *curl -sSL https://install.python-poetry.org | python3 -*
 
 Для WINDOWS вводим в PowerShell
 
-> *(Invoke-WebRequest
--Uri https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
--UseBasicParsing).Content | python -*
+> *(Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | py -*
 
 После установки перезапустите оболочку и введите команду
 
@@ -27,6 +23,15 @@ Poetry - это инструмент для управления зависим�
 Ответ должен быть в формате
 
 > Poetry version 1.1.13
+
+В случае, если вы видите ошибку "команда не найдена", проверьте, что в PATH внесён путь
+(вместо USERNAME должно быть имя пользователя):
+> C:\Users\USERNAME\AppData\Roaming\Python\Scripts (для Windows)
+>
+> /Users/USERNAME/Library/Application Support/pypoetry/venv/bin (для Mac)
+
+Здесь вы можете ознакомиться подробнее с процессом установки Poetry:
+> https://python-poetry.org/docs/#installation
 
 Для дальнейшей работы введите команду:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "lomaya_baryery_backend"
+version = "0.1.0"
+description = "Lomaya Baryery tg_bot backend"
+authors = ["Yandex Practicum Team backend_5+"]
+
+
+[tool.poetry.dependencies]
+environs = "~9.5.0"
+python-telegram-bot = "~20.0a4"
+asyncpg = "0.24.0"
+uvicorn = "~0.18.3"
+fastapi = "~0.82.0"
+sqlmodel = "~0.0.8"
+alembic = "~1.7.1"
+python = "^3.8"


### PR DESCRIPTION
Исправлены команды установки poetry,
Добавлены замечания по PATH при установке,
**Добавлен Тестовый файл pyproject.toml с зависимостями для обеспечения запуска установки Poetry**

pyproject.toml пришлось добавить так как без него не запускается poetry install и не устанавливается виртуальное окружение. Если это критично, то этот файл можно убрать из реквеста.