### PR TITLE
API: Запрет лишних входных данных в запросах

### DIFF
--- a/src/api/request_models/request_base.py
+++ b/src/api/request_models/request_base.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, Extra
+
+
+class RequestBase(BaseModel):
+    """Базовый класс для моделей запросов.
+
+    Запрещена передача полей не предусмотренных схемой."""
+
+    class Config:
+        extra = Extra.forbid

--- a/src/api/request_models/shift.py
+++ b/src/api/request_models/shift.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, timedelta
 
 from pydantic import validator
 
-from .request_base import RequestBase
+from src.api.request_models.request_base import RequestBase
 
 
 class ShiftCreateRequest(RequestBase):

--- a/src/api/request_models/shift.py
+++ b/src/api/request_models/shift.py
@@ -1,9 +1,11 @@
 from datetime import date, datetime, timedelta
 
-from pydantic import BaseModel, validator
+from pydantic import validator
+
+from .request_base import RequestBase
 
 
-class ShiftCreateRequest(BaseModel):
+class ShiftCreateRequest(RequestBase):
     started_at: datetime
     finished_at: datetime
 

--- a/src/api/request_models/user_task.py
+++ b/src/api/request_models/user_task.py
@@ -1,6 +1,6 @@
 from pydantic import Field, validator
 
-from .request_base import RequestBase
+from src.api.request_models.request_base import RequestBase
 from src.core.db.models import UserTask
 
 

--- a/src/api/request_models/user_task.py
+++ b/src/api/request_models/user_task.py
@@ -1,9 +1,10 @@
-from pydantic import BaseModel, Field, validator
+from pydantic import Field, validator
 
+from .request_base import RequestBase
 from src.core.db.models import UserTask
 
 
-class ChangeStatusRequest(BaseModel):
+class ChangeStatusRequest(RequestBase):
     """Модель изменения статуса."""
 
     status: UserTask.Status = Field(UserTask.Status.APPROVED.value)


### PR DESCRIPTION
API: Запрет лишних входных данных в запросах

Создан базовый класс пидантик RequestBase(BaseModel) для запросов API.
В классе запрещены поля, не предусмотренные схемой

Классы ShiftCreateRequest и ChangeStatusRequest  теперь наследуются от RequestBase
