### PR TITLE
Feature/spisok zadach po status i shift

### DIFF
--- a/src/api/request_models/user_task.py
+++ b/src/api/request_models/user_task.py
@@ -14,3 +14,8 @@ class ChangeStatusRequest(RequestBase):
         if value not in (UserTask.Status.APPROVED.value, UserTask.Status.DECLINED.value):
             raise ValueError("Недопустимый статус отчета")
         return value
+
+
+class ChangeStatusByShiftRequest(RequestBase):
+    """Модель изменения статуса."""
+    pass

--- a/src/api/response_models/user_task.py
+++ b/src/api/response_models/user_task.py
@@ -34,3 +34,20 @@ class UserTaskResponse(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class UserTaskStatusByShiftResponse(BaseModel):
+    shift_id: UUID
+    shift_status: str
+    shift_started_at: date
+    user_task_id: UUID
+    user_task_created_at: date
+    user_name: str
+    user_surname: str
+    task_id: UUID
+    task_description: str
+    task_url: str
+    photo_url: str
+
+    class Config:
+        orm_mode = True

--- a/src/api/routers/user_tasks.py
+++ b/src/api/routers/user_tasks.py
@@ -9,7 +9,10 @@ from pydantic.schema import UUID
 from src.api.response_models.user_task import (
     UserTaskResponse,
     UserTasksAndShiftResponse,
+    UserTaskStatusByShiftResponse
 )
+from src.api.request_models.user_task import ChangeStatusByShiftRequest
+from src.core.db.models import UserTask
 from src.core.services.shift_service import ShiftService
 from src.core.services.user_task_service import UserTaskService
 
@@ -89,3 +92,55 @@ class UserTasksCBV:
         report["shift"] = shift
         report["tasks"] = tasks
         return report
+
+    @router.get(
+        "/{shift_id}/{status}",
+        response_model=list[UserTaskStatusByShiftResponse],
+        summary="Получения списка задач на проверку по полям status и shift_id.",
+    )
+    async def get_tasks_by_status(
+        *,
+        self,
+        shift_id: UUID,
+        status: UserTask.Status,
+    ) -> list[UserTaskStatusByShiftResponse]:
+        """
+        Получения списка задач на проверку с возможностью фильтрации по полям status и shift_id.
+
+        Список формируется по убыванию поля started_at.
+
+        В запросе передаётся:
+
+        - **shift_id**: уникальный id смены, ожидается в формате UUID.uuid4
+        - **user_task.status**: статус задачи
+        """
+        return await (
+            self.user_task_service
+            .get_user_task_by_shift_id_and_status(shift_id, status)
+        )
+
+    @router.patch(
+        "/{shift_id}/{status}",
+        response_model=list[UserTaskStatusByShiftResponse],
+        response_model_exclude_none=True,
+        status_code=HTTPStatus.OK,
+        summary="Изменить статус участника.",
+        response_description="Полная информация об отчёте участника."
+    )
+    async def update_status_by_shift(
+        *,
+        self,
+        shift_id: UUID,
+        status: UserTask.Status,
+        update_status_by_shift: ChangeStatusByShiftRequest,
+    ) -> list[UserTaskStatusByShiftResponse]:
+        """Изменить статус отчета участника.
+
+        - **user_id**:номер участника
+        - **status**: статус задачи
+        """
+        return await (
+            self.user_task_service
+            .patch_user_task_by_shift_id_and_status(
+                shift_id, status, update_status_by_shift)
+        )

--- a/src/core/services/user_task_service.py
+++ b/src/core/services/user_task_service.py
@@ -8,6 +8,7 @@ from pydantic.schema import UUID
 
 from src.api.request_models.request import Status
 from src.api.response_models.task import LongTaskResponse
+from src.api.request_models.user_task import ChangeStatusByShiftRequest
 from src.bot.services import BotService
 from src.core.db.models import UserTask
 from src.core.db.repository import (
@@ -135,3 +136,28 @@ class UserTaskService:
                     )
                 )
         await self.__user_task_repository.create_all(result)
+
+    async def get_user_task_by_shift_id_and_status(
+        self, shift_id: UUID, status: str
+    ) -> list[dict]:
+        return await (
+            self.__user_task_repository
+            .get_user_task_status_by_shift_id(shift_id, status)
+        )
+
+    async def patch_user_task_by_shift_id_and_status(
+        self, shift_id: UUID, status: UserTask.Status,
+        user_status_by_shift: ChangeStatusByShiftRequest
+    ) -> dict:
+        await (
+            self.__user_task_repository
+            .patch_user_task_status_by_shift(
+                shift_id=shift_id,
+                status=status,
+                user_task=user_status_by_shift
+            )
+        )
+        return await (
+            self.__user_task_repository
+            .get_user_task_status_by_shift_id(shift_id, status)
+        )


### PR DESCRIPTION
The task draft version has been completed. 
Both Get and Patch seemed to work.

The output supports list of dict and single dict per one shift only.

Can't achieve the follow requirement:

**_" Список формируется по убыванию поля started_at. "_**

Within the code:
 ```python 
@router.get(
        "/{shift_id}/{status}",
        response_model=list[UserTaskStatusByShiftResponse],
        summary="Получения списка задач на проверку по полям status и shift_id.",
    )
    async def get_tasks_by_status(
        *,
        self,
        shift_id: list[UUID] = Path(..., title="ID смены"),
        status: UserTask.Status,
    ) -> list[dict]:
```
the output is the assertion error:
```
assert is_scalar_field(
                   AssertionError: Path params must be of one of the supported types
```