### PR TITLE
Refactored distribute_tasks_on_shift function

### DIFF
--- a/src/core/services/user_task_service.py
+++ b/src/core/services/user_task_service.py
@@ -108,25 +108,25 @@ class UserTaskService:
         if status is UserTask.Status.NEW:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=NEW_TASK.format(status))
 
-    # TODO переписать
     async def distribute_tasks_on_shift(
         self,
         shift_id: UUID,
     ) -> None:
         """Раздача участникам заданий на 3 месяца.
 
-        Задачи раздаются случайным образом.
+        Перед раздачей задачи перемешиваются один раз случайным образом.
+        Всем участникам на каждый день смены назначается одна и та же задача.
+
         Метод запускается при старте смены.
         """
         current_shift = await self.__shift_repository.get(shift_id)
+        number_days = (current_shift.finished_at - current_shift.created_at).days
+        all_dates = tuple((current_shift.created_at + timedelta(day)) for day in range(number_days))
         task_ids_list = await self.__task_service.get_task_ids_list()
+        random.shuffle(task_ids_list)
         user_ids_list = await self.__request_service.get_approved_shift_user_ids(shift_id)
-
         result = []
         for user_id in user_ids_list:
-            random.shuffle(task_ids_list)
-            number_days = (current_shift.finished_at - current_shift.created_at).days
-            all_dates = tuple((current_shift.created_at + timedelta(day)) for day in range(number_days))
             for one_date in all_dates:
                 result.append(
                     UserTask(


### PR DESCRIPTION
Задача: https://www.notion.so/Refactoring-distribute_tasks_on_shift-58604337f2fa47f78603fdf48984f4ca
1. Вынес из цикла по юзерам функцию по перемешиванию списка задач. Теперь она запускается один раз перед циклом, а не на каждой итерации. Все юзеры в итоге получат одинаковые задания в один и тот же день смены.
2. Дополнил докстринг.
3. Также вынес из цикла две строки, составляющие кортеж из всех дат смены (all_dates). Нет смысла делать одно и тоже для каждого юзера отдельно, т.к. кортеж будет для всех одинаковым.