### PR TITLE
Bugfix/request approve

### DIFF
--- a/src/api/response_models/request.py
+++ b/src/api/response_models/request.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 from datetime import date
 from uuid import UUID
 
 from pydantic import BaseModel
+
+from src.core.db.models import Request
 
 
 class RequestResponse(BaseModel):
@@ -13,3 +17,17 @@ class RequestResponse(BaseModel):
     city: str
     phone_number: str
     status: str
+
+    @classmethod
+    def parse_from(cls, request_obj: Request) -> RequestResponse:
+        """Парсит модель sqlalchemy Request, полученной с помощью метода get класса RequestRepository."""
+        return cls(
+            request_id=request_obj.id,
+            user_id=request_obj.user.id,
+            name=request_obj.user.name,
+            surname=request_obj.user.surname,
+            date_of_birth=request_obj.user.date_of_birth,
+            city=request_obj.user.city,
+            phone_number=request_obj.user.phone_number,
+            status=request_obj.status,
+        )

--- a/src/api/routers/request.py
+++ b/src/api/routers/request.py
@@ -5,6 +5,7 @@ from fastapi_restful.cbv import cbv
 from pydantic.schema import UUID
 
 from src.api.request_models.request import RequestDeclineRequest
+from src.api.response_models.request import RequestResponse
 from src.core.services.request_sevice import RequestService
 
 router = APIRouter(prefix="/requests", tags=["Request"])
@@ -16,6 +17,7 @@ class RequestCBV:
 
     @router.patch(
         "/{request_id}/approve",
+        response_model=RequestResponse,
         status_code=HTTPStatus.OK,
         summary="Одобрить заявку на участие.",
     )
@@ -23,12 +25,13 @@ class RequestCBV:
         self,
         request_id: UUID,
         request: Request,
-    ) -> None:
+    ) -> RequestResponse:
         """Одобрить заявку на участие в акции."""
         return await self.request_service.approve_request(request_id, request.app.state.bot_instance.bot)
 
     @router.patch(
         "/{request_id}/decline",
+        response_model=RequestResponse,
         status_code=HTTPStatus.OK,
         summary="Отклонить заявку на участие.",
     )
@@ -37,7 +40,7 @@ class RequestCBV:
         request_id: UUID,
         decline_request_data: RequestDeclineRequest,
         request: Request,
-    ) -> None:
+    ) -> RequestResponse:
         """Отклонить заявку на участие в акции."""
         return await self.request_service.decline_request(
             request_id, request.app.state.bot_instance.bot, decline_request_data

--- a/src/api/routers/request.py
+++ b/src/api/routers/request.py
@@ -17,6 +17,7 @@ class RequestCBV:
 
     @router.patch(
         "/{request_id}/approve",
+        response_model=RequestResponse,
         status_code=HTTPStatus.OK,
         summary="Одобрить заявку на участие.",
     )
@@ -30,6 +31,7 @@ class RequestCBV:
 
     @router.patch(
         "/{request_id}/decline",
+        response_model=RequestResponse,
         status_code=HTTPStatus.OK,
         summary="Отклонить заявку на участие.",
     )

--- a/src/api/routers/request.py
+++ b/src/api/routers/request.py
@@ -5,7 +5,6 @@ from fastapi_restful.cbv import cbv
 from pydantic.schema import UUID
 
 from src.api.request_models.request import RequestDeclineRequest
-from src.api.response_models.request import RequestResponse
 from src.core.services.request_sevice import RequestService
 
 router = APIRouter(prefix="/requests", tags=["Request"])
@@ -17,7 +16,6 @@ class RequestCBV:
 
     @router.patch(
         "/{request_id}/approve",
-        response_model=RequestResponse,
         status_code=HTTPStatus.OK,
         summary="Одобрить заявку на участие.",
     )
@@ -25,13 +23,12 @@ class RequestCBV:
         self,
         request_id: UUID,
         request: Request,
-    ) -> RequestResponse:
+    ) -> None:
         """Одобрить заявку на участие в акции."""
         return await self.request_service.approve_request(request_id, request.app.state.bot_instance.bot)
 
     @router.patch(
         "/{request_id}/decline",
-        response_model=RequestResponse,
         status_code=HTTPStatus.OK,
         summary="Отклонить заявку на участие.",
     )
@@ -40,7 +37,7 @@ class RequestCBV:
         request_id: UUID,
         decline_request_data: RequestDeclineRequest,
         request: Request,
-    ) -> RequestResponse:
+    ) -> None:
         """Отклонить заявку на участие в акции."""
         return await self.request_service.decline_request(
             request_id, request.app.state.bot_instance.bot, decline_request_data

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -53,10 +53,9 @@ class ShiftFinishForbiddenException(ApplicationException):
 class SendTelegramNotifyException(ApplicationException):
     """Невозможно отправить сообщение в telegram."""
 
-    def __init__(self, user_id: UUID, user_name: str, telegram_id: int):
+    def __init__(self, user_id: UUID, user_name: str, surname: str, telegram_id: int, exc: Exception):
         self.status_code = HTTPStatus.BAD_REQUEST
         self.detail = (
-            "Ошибка при отправке сообщения пользователю - "
-            f"id: {user_id}, name: {user_name}, telegram_id: {telegram_id}. "
-            "Пожалуйста, проверьте, что пользователь с таким telegram_id доступен в telegram."
+            f"Возникла ошибка '{exc}' при отправке сообщения пользователю - "
+            f"id: {user_id}, Имя: {user_name}, Фамилия: {surname}, Телеграм id: {telegram_id}"
         )

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -48,3 +48,15 @@ class ShiftFinishForbiddenException(ApplicationException):
     def __init__(self, shift_name: str, shift_id: UUID):
         self.status_code = HTTPStatus.BAD_REQUEST
         self.detail = f"Невозможно завершить смену {shift_name} с id: {shift_id}. Проверьте статус смены"
+
+
+class SendTelegramNotifyException(ApplicationException):
+    """Невозможно отправить сообщение в telegram."""
+
+    def __init__(self, user_id: UUID, user_name: str, telegram_id: int):
+        self.status_code = HTTPStatus.BAD_REQUEST
+        self.detail = (
+            "Ошибка при отправке сообщения пользователю - "
+            f"id: {user_id}, name: {user_name}, telegram_id: {telegram_id}. "
+            "Пожалуйста, проверьте, что пользователь с таким telegram_id доступен в telegram."
+        )

--- a/src/core/services/request_sevice.py
+++ b/src/core/services/request_sevice.py
@@ -25,14 +25,14 @@ class RequestService:
     async def approve_request(self, request_id: UUID, bot: Application.bot) -> None:
         """Заявка одобрена: обновление статуса, уведомление участника в телеграм."""
         request = await self.__request_repository.get(request_id)
-        if request.status is Status.APPROVED:
+        if request.status == Status.APPROVED:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=REVIEWED_REQUEST.format(request.status))
         request.status = Status.APPROVED
         await self.__request_repository.update(request_id, request)
         member = Member(user_id=request.user_id, shift_id=request.shift_id)
         await self.__member_repository.create(member)
         await self.__telegram_bot(bot).notify_approved_request(request.user)
-        return
+        return request
 
     async def decline_request(
         self,
@@ -42,12 +42,12 @@ class RequestService:
     ) -> None:
         """Заявка отклонена: обновление статуса, уведомление участника в телеграм."""
         request = await self.__request_repository.get(request_id)
-        if request.status is Status.DECLINED:
+        if request.status == Status.DECLINED:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=REVIEWED_REQUEST.format(request.status))
         request.status = Status.DECLINED
         await self.__request_repository.update(request_id, request)
         await self.__telegram_bot(bot).notify_declined_request(request.user, decline_request_data)
-        return
+        return request
 
     async def exclude_members(self, user_ids: list[UUID], shift_id: UUID, bot: Application.bot) -> None:
         """Исключает участников смены.

--- a/src/core/services/request_sevice.py
+++ b/src/core/services/request_sevice.py
@@ -2,7 +2,6 @@ from http import HTTPStatus
 
 from fastapi import Depends, HTTPException
 from pydantic.schema import UUID
-from telegram.error import BadRequest
 from telegram.ext import Application
 
 from src.api.request_models.request import RequestDeclineRequest
@@ -25,53 +24,42 @@ class RequestService:
         self.__member_repository = member_repository
         self.__telegram_bot = services.BotService
 
-    async def __create_request_response_model(self, request: Request):
-        request_response = RequestResponse(
-            request_id=request.id,
-            user_id=request.user.id,
-            name=request.user.name,
-            surname=request.user.surname,
-            date_of_birth=request.user.date_of_birth,
-            city=request.user.city,
-            phone_number=request.user.phone_number,
-            status=request.status,
-        )
-        return request_response  # noqa: R504
-
-    async def approve_request(self, request_id: UUID, bot: Application.bot) -> None:
+    async def approve_request(self, request_id: UUID, bot: Application.bot) -> RequestResponse:
         """Заявка одобрена: обновление статуса, уведомление участника в телеграм."""
         request = await self.__request_repository.get(request_id)
-        if request.status != Request.Status.PENDING and request.status != Request.Status.REPEATED_REQUEST:
+        if request.status not in (Request.Status.PENDING, Request.Status.REPEATED_REQUEST):
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=REVIEWED_REQUEST.format(request.status))
         try:
             await self.__telegram_bot(bot).notify_approved_request(request.user)
-        except BadRequest:
-            raise SendTelegramNotifyException(request.user.id, request.user.name, request.user.telegram_id)
-        else:
-            request.status = Request.Status.APPROVED
-            await self.__request_repository.update(request_id, request)
-            member = Member(user_id=request.user_id, shift_id=request.shift_id)
-            await self.__member_repository.create(member)
-        return await self.__create_request_response_model(request)
+        except Exception as exc:
+            raise SendTelegramNotifyException(
+                request.user.id, request.user.name, request.user.surname, request.user.telegram_id, exc
+            )
+        request.status = Request.Status.APPROVED
+        await self.__request_repository.update(request_id, request)
+        member = Member(user_id=request.user_id, shift_id=request.shift_id)
+        await self.__member_repository.create(member)
+        return RequestResponse.parse_from(request)
 
     async def decline_request(
         self,
         request_id: UUID,
         bot: Application.bot,
         decline_request_data: RequestDeclineRequest,
-    ) -> None:
+    ) -> RequestResponse:
         """Заявка отклонена: обновление статуса, уведомление участника в телеграм."""
         request = await self.__request_repository.get(request_id)
-        if request.status != Request.Status.PENDING and request.status != Request.Status.REPEATED_REQUEST:
+        if request.status not in (Request.Status.PENDING, Request.Status.REPEATED_REQUEST):
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=REVIEWED_REQUEST.format(request.status))
         try:
             await self.__telegram_bot(bot).notify_declined_request(request.user, decline_request_data)
-        except BadRequest:
-            raise SendTelegramNotifyException(request.user.id, request.user.name, request.user.telegram_id)
-        else:
-            request.status = Request.Status.DECLINED
-            await self.__request_repository.update(request_id, request)
-        return await self.__create_request_response_model(request)
+        except Exception as exc:
+            raise SendTelegramNotifyException(
+                request.user.id, request.user.name, request.user.surname, request.user.telegram_id, exc
+            )
+        request.status = Request.Status.DECLINED
+        await self.__request_repository.update(request_id, request)
+        return RequestResponse.parse_from(request)
 
     async def exclude_members(self, user_ids: list[UUID], shift_id: UUID, bot: Application.bot) -> None:
         """Исключает участников смены.

--- a/src/core/services/request_sevice.py
+++ b/src/core/services/request_sevice.py
@@ -41,7 +41,7 @@ class RequestService:
     async def approve_request(self, request_id: UUID, bot: Application.bot) -> None:
         """Заявка одобрена: обновление статуса, уведомление участника в телеграм."""
         request = await self.__request_repository.get(request_id)
-        if request.status == Status.APPROVED:
+        if request.status != Request.Status.PENDING or request.status != Request.Status.REPEATED_REQUEST:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=REVIEWED_REQUEST.format(request.status))
         try:
             await self.__telegram_bot(bot).notify_approved_request(request.user)
@@ -62,7 +62,7 @@ class RequestService:
     ) -> None:
         """Заявка отклонена: обновление статуса, уведомление участника в телеграм."""
         request = await self.__request_repository.get(request_id)
-        if request.status == Status.DECLINED:
+        if request.status != Request.Status.PENDING or request.status != Request.Status.REPEATED_REQUEST:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=REVIEWED_REQUEST.format(request.status))
         try:
             await self.__telegram_bot(bot).notify_declined_request(request.user, decline_request_data)

--- a/src/core/services/request_sevice.py
+++ b/src/core/services/request_sevice.py
@@ -41,7 +41,7 @@ class RequestService:
     async def approve_request(self, request_id: UUID, bot: Application.bot) -> None:
         """Заявка одобрена: обновление статуса, уведомление участника в телеграм."""
         request = await self.__request_repository.get(request_id)
-        if request.status != Request.Status.PENDING or request.status != Request.Status.REPEATED_REQUEST:
+        if request.status != Request.Status.PENDING and request.status != Request.Status.REPEATED_REQUEST:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=REVIEWED_REQUEST.format(request.status))
         try:
             await self.__telegram_bot(bot).notify_approved_request(request.user)
@@ -62,7 +62,7 @@ class RequestService:
     ) -> None:
         """Заявка отклонена: обновление статуса, уведомление участника в телеграм."""
         request = await self.__request_repository.get(request_id)
-        if request.status != Request.Status.PENDING or request.status != Request.Status.REPEATED_REQUEST:
+        if request.status != Request.Status.PENDING and request.status != Request.Status.REPEATED_REQUEST:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=REVIEWED_REQUEST.format(request.status))
         try:
             await self.__telegram_bot(bot).notify_declined_request(request.user, decline_request_data)

--- a/src/core/services/request_sevice.py
+++ b/src/core/services/request_sevice.py
@@ -5,7 +5,7 @@ from pydantic.schema import UUID
 from telegram.error import BadRequest
 from telegram.ext import Application
 
-from src.api.request_models.request import RequestDeclineRequest, Status
+from src.api.request_models.request import RequestDeclineRequest
 from src.api.response_models.request import RequestResponse
 from src.bot import services
 from src.core.db.models import Member, Request
@@ -48,7 +48,7 @@ class RequestService:
         except BadRequest:
             raise SendTelegramNotifyException(request.user.id, request.user.name, request.user.telegram_id)
         else:
-            request.status = Status.APPROVED
+            request.status = Request.Status.APPROVED
             await self.__request_repository.update(request_id, request)
             member = Member(user_id=request.user_id, shift_id=request.shift_id)
             await self.__member_repository.create(member)
@@ -69,7 +69,7 @@ class RequestService:
         except BadRequest:
             raise SendTelegramNotifyException(request.user.id, request.user.name, request.user.telegram_id)
         else:
-            request.status = Status.DECLINED
+            request.status = Request.Status.DECLINED
             await self.__request_repository.update(request_id, request)
         return await self.__create_request_response_model(request)
 

--- a/src/core/services/request_sevice.py
+++ b/src/core/services/request_sevice.py
@@ -32,7 +32,7 @@ class RequestService:
         member = Member(user_id=request.user_id, shift_id=request.shift_id)
         await self.__member_repository.create(member)
         await self.__telegram_bot(bot).notify_approved_request(request.user)
-        return request
+        return
 
     async def decline_request(
         self,
@@ -47,7 +47,7 @@ class RequestService:
         request.status = Status.DECLINED
         await self.__request_repository.update(request_id, request)
         await self.__telegram_bot(bot).notify_declined_request(request.user, decline_request_data)
-        return request
+        return
 
     async def exclude_members(self, user_ids: list[UUID], shift_id: UUID, bot: Application.bot) -> None:
         """Исключает участников смены.

--- a/src/core/services/request_sevice.py
+++ b/src/core/services/request_sevice.py
@@ -36,7 +36,7 @@ class RequestService:
             phone_number=request.user.phone_number,
             status=request.status,
         )
-        return request_response
+        return request_response  # noqa: R504
 
     async def approve_request(self, request_id: UUID, bot: Application.bot) -> None:
         """Заявка одобрена: обновление статуса, уведомление участника в телеграм."""


### PR DESCRIPTION
Задачи
https://www.notion.so/BUGREQ-1A-500-Internal-Server-Error-PATCH-reque-7e828ba525bb4ab58fa41bd2e9b05d24
https://www.notion.so/BUGREQ-2A-500-Internal-Server-Error-PATCH-reque-9a2d6e8b83034a01b243911bd11530e7

Объединил в один PR и одну ветку, так как все функции смежные.

Ошибки возникали из-за того, что в тестовой базе находятся фейковые telegram_id. В проде должно без ошибок работать, но на всякий случай добавил обработку исключения. Плюс поправил баг с использованием **is** вместо **==** в проверке статуса заявки, из-за чего тоже выбрасывало исключение. 

Добавил обработку исключения при отправке сообщения пользователю в телеграм и перенёс обновление данных в базе после отправки сообщения, чтобы в случае если сообщение не отправилось, то не приходилось в ручную как-то менять данные в базе. Иначе заявка будет отклонена или одобрена, а пользователь об этом не узнает и придётся ему вручную отправлять сообщение.

Добавил парсер модели sqlalchemy в pydentic модель, чтобы тому, кто одобряет или отклоняет заявку, приходил нормальный ответ. Не очень понял в итоге, должен был быть ответ или нет. Потому что переменная response_model в роутере отсутствовала, а в самой функции указан type_hint -> RequestResponse. К тому же в [таблице](https://docs.google.com/spreadsheets/d/1YAxQ8Cbf5n9MsQ1gk892SYS0s_8jMF8m-1c3i9a9ACA/edit#gid=45075582) тестеров такой ответ является ожидаемым.

Я бы изменил RequestResponse, чтобы не приходилось отдельно парсить модель из алхимии в pydentic.  Например:
```
class RequestResponse(BaseModel):
    request_id: UUID
    status: str
    user: UserResponse
```