### PR TITLE
bump isort up to 5.12.0 according PyCQA/isort#2077

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       args: [--branch, master, --branch, develop]
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
       args: [--settings, setup.cfg]


### PR DESCRIPTION
Поднимаем версию isort согласно рекомендациям [PyCQA/isort#2077](https://github.com/PyCQA/isort/issues/2077).

Задача: [Ломая барьеры/Доска задач](https://www.notion.so/bug-pre-commit-isort-46c0a6d59b8a42df98b026075058e7e7)
