### PR TITLE
Added response for report approve/decline methods

### DIFF
--- a/src/api/response_models/report.py
+++ b/src/api/response_models/report.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from typing import Optional
 
 from pydantic import BaseModel
@@ -20,27 +20,17 @@ class UserAndTaskInfoResponse(UserInfoResponse, TaskInfoResponse):
 class ReportResponse(BaseModel):
     """Pydantic-схема, для описания объекта, полученного из БД."""
 
-    user_id: UUID
-    id: UUID
+    shift_id: UUID
     task_id: UUID
+    member_id: UUID
     task_date: date
     status: Report.Status
-    photo_url: Optional[str]
+    report_url: Optional[str]
+    uploaded_at: datetime
+    number_attempt: int
 
     class Config:
         orm_mode = True
-
-    @classmethod
-    def parse_from(cls, obj: Report) -> ReportResponse:
-        """Конвертация данных из модели Report."""
-        return cls(
-            user_id=obj.member.user_id,
-            id=obj.id,
-            task_id=obj.task_id,
-            task_date=obj.task_date,
-            status=obj.status,
-            photo_url=obj.report_url,
-        )
 
 
 class ReportSummaryResponse(BaseModel):

--- a/src/api/routers/report.py
+++ b/src/api/routers/report.py
@@ -49,7 +49,7 @@ class ReportsCBV:
         "/{report_id}/approve",
         status_code=HTTPStatus.OK,
         summary="Принять задание. Будет начислен 1 \"ломбарьерчик\".",
-        response_model=None,
+        response_model=ReportResponse,
         responses={
             404: ERROR_TEMPLATE_FOR_404,
             403: ERROR_TEMPLATE_FOR_403,
@@ -59,7 +59,7 @@ class ReportsCBV:
         self,
         report_id: UUID,
         request: Request,
-    ) -> HTTPStatus.OK:
+    ) -> ReportResponse:
         """Отчет участника проверен и принят."""
         return await self.report_service.approve_report(report_id, request.app.state.bot_instance)
 
@@ -67,7 +67,7 @@ class ReportsCBV:
         "/{report_id}/decline",
         status_code=HTTPStatus.OK,
         summary="Отклонить задание.",
-        response_model=None,
+        response_model=ReportResponse,
         responses={
             404: ERROR_TEMPLATE_FOR_404,
             403: ERROR_TEMPLATE_FOR_403,
@@ -77,7 +77,7 @@ class ReportsCBV:
         self,
         report_id: UUID,
         request: Request,
-    ) -> HTTPStatus.OK:
+    ) -> ReportResponse:
         """Отчет участника проверен и отклонен."""
         return await self.report_service.decline_report(report_id, request.app.state.bot_instance)
 

--- a/src/core/services/report_service.py
+++ b/src/core/services/report_service.py
@@ -63,23 +63,21 @@ class ReportService:
         """Задание принято: изменение статуса, начисление 1 /"ломбарьерчика/", уведомление участника."""
         report = await self.__report_repository.get(report_id)
         self.__can_change_status(report.status)
-        report.status = Report.Status.APPROVED
-        updated_report = await self.__report_repository.update(report_id, report)
         member = await self.__member_repository.get_with_user(report.member_id)
         member.numbers_lombaryers += 1
         await self.__member_repository.update(member.id, member)
         await self.__telegram_bot(bot).notify_approved_task(member.user, report)
-        return updated_report
+        report.status = Report.Status.APPROVED
+        return await self.__report_repository.update(report_id, report)
 
     async def decline_report(self, report_id: UUID, bot: Application) -> ReportResponse:
         """Задание отклонено: изменение статуса, уведомление участника в телеграм."""
         report = await self.__report_repository.get(report_id)
         self.__can_change_status(report.status)
-        report.status = Report.Status.DECLINED
-        updated_report = await self.__report_repository.update(report_id, report)
         member = await self.__member_repository.get_with_user(report.member_id)
         await self.__telegram_bot(bot).notify_declined_task(member.user)
-        return updated_report
+        report.status = Report.Status.DECLINED
+        return await self.__report_repository.update(report_id, report)
 
     def __can_change_status(self, status: Report.Status) -> None:
         """Проверка статуса задания перед изменением."""

--- a/src/core/services/report_service.py
+++ b/src/core/services/report_service.py
@@ -45,8 +45,7 @@ class ReportService:
         return await self.__report_repository.get(id)
 
     async def get_report_with_report_url(self, id: UUID) -> ReportResponse:
-        report = await self.__report_repository.get_report_with_report_url(id)
-        return ReportResponse.parse_from(report)
+        return await self.__report_repository.get_report_with_report_url(id)
 
     async def check_duplicate_report(self, url: str) -> None:
         report = await self.__report_repository.get_by_report_url(url)
@@ -70,7 +69,7 @@ class ReportService:
         member.numbers_lombaryers += 1
         await self.__member_repository.update(member.id, member)
         await self.__telegram_bot(bot).notify_approved_task(member.user, report)
-        return ReportResponse.parse_from(updated_report)
+        return updated_report
 
     async def decline_report(self, report_id: UUID, bot: Application) -> ReportResponse:
         """Задание отклонено: изменение статуса, уведомление участника в телеграм."""
@@ -80,7 +79,7 @@ class ReportService:
         updated_report = await self.__report_repository.update(report_id, report)
         member = await self.__member_repository.get_with_user(report.member_id)
         await self.__telegram_bot(bot).notify_declined_task(member.user)
-        return ReportResponse.parse_from(updated_report)
+        return updated_report
 
     def __can_change_status(self, status: Report.Status) -> None:
         """Проверка статуса задания перед изменением."""


### PR DESCRIPTION
Задача: https://www.notion.so/Fix-5b99376aaa784e65b5264242062add2f

1. Добавил ReportResponse в response_model в роутере.
2. Добавил ReportResponse в return для методов approve_report, decline_report.

Теперь обе ручки возвращают сущность согласно модели ReportResponse и в swagger формат ответа для 200 отображается соответственно.