### PR TITLE
Added shifts sorting with several statuses

### DIFF
--- a/src/api/routers/shift.py
+++ b/src/api/routers/shift.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from fastapi import Request as FastAPIRequest
 from fastapi_restful.cbv import cbv
 
@@ -176,7 +176,7 @@ class ShiftCBV:
     )
     async def get_all_shifts(
         self,
-        status: Optional[Shift.Status] = None,
+        status: Optional[list[Shift.Status]] = Query(default=None),
         sort: Optional[ShiftSortRequest] = None,
     ) -> list[ShiftWithTotalUsersResponse]:
         """Получить список смен с фильтрацией по статусу.

--- a/src/core/db/repository/shift_repository.py
+++ b/src/core/db/repository/shift_repository.py
@@ -74,7 +74,7 @@ class ShiftRepository(AbstractRepository):
 
     async def get_shifts_with_total_users(
         self,
-        status: Optional[Shift.Status],
+        status: Optional[list[Shift.Status]],
         sort: Optional[ShiftSortRequest],
     ) -> list:
         shifts = (
@@ -90,9 +90,7 @@ class ShiftRepository(AbstractRepository):
             )
             .outerjoin(Shift.requests)
             .group_by(Shift.id)
-            .where(
-                or_(status is None, Shift.status == status),
-            )
+            .where(status is None or Shift.status.in_(status))
             .order_by(sort or Shift.started_at.desc())
         )
         shifts = await self._session.execute(shifts)

--- a/src/core/services/shift_service.py
+++ b/src/core/services/shift_service.py
@@ -223,7 +223,7 @@ class ShiftService:
         return await self.__shift_repository.list_all_requests(id=id, status=status)
 
     async def list_all_shifts(
-        self, status: Optional[Shift.Status] = None, sort: Optional[ShiftSortRequest] = None
+        self, status: Optional[list[Shift.Status]] = None, sort: Optional[ShiftSortRequest] = None
     ) -> list[ShiftWithTotalUsersResponse]:
         return await self.__shift_repository.get_shifts_with_total_users(status, sort)
 


### PR DESCRIPTION
Задача: https://www.notion.so/Refactoring-GET-shifts-e4364487c1c646a096f10cb8849631c2

Поменял алхимический `or_` на питоновский `or`, т.к. с ним почему-то выскакивала ошибка, когда пытаешься получить все смены (без сортировок по статусу).