### PR TITLE
Add administrator invitation fix

### DIFF
--- a/src/core/db/repository/administrator_repository.py
+++ b/src/core/db/repository/administrator_repository.py
@@ -14,17 +14,34 @@ class AdministratorRepository(AbstractRepository):
     def __init__(self, session: AsyncSession = Depends(get_session)) -> None:
         super().__init__(session, Administrator)
 
+    async def _get_by_email(self, email: str) -> Administrator:
+        """Метод для получения администратора из БД по email.
+
+        Аргументы:
+            email (str) - email администратора.
+        """
+        administrator = await self._session.execute(select(Administrator).where(Administrator.email == email))
+        return administrator.scalars().first()
+
     async def get_by_email(self, email: str) -> Administrator:
         """Получает из БД администратора по его email. В случае отсутствия бросает ошибку.
 
         Аргументы:
             email (str) - email администратора.
         """
-        administrator = await self._session.execute(select(Administrator).where(Administrator.email == email))
-        administrator = administrator.scalars().first()
+        administrator = await self._get_by_email(email)
         if not administrator:
             raise AdministratorNotFoundException()
         return administrator
+
+    async def check_administrator_existence(self, email: str) -> bool:
+        """Проверяет существование администратора по email.
+
+        Аргументы:
+            email (str) - email администратора.
+        """
+        administrator_exists = await self._get_by_email(email)
+        return bool(administrator_exists)
 
     async def get_administrators_filter_by_role_and_status(
         self, status: Administrator.Status | None, role: Administrator.Role | None

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -213,6 +213,13 @@ class AdministratorNotFoundException(ApplicationException):
     detail = "Пользователь с указанными реквизитами не найден."
 
 
+class AdministratorAlreadyExistsException(ApplicationException):
+    """Пользователь с таким email уже существует."""
+
+    status_code = HTTPStatus.BAD_REQUEST
+    detail = "Администратор с указанным email уже существует."
+
+
 class AdministratorInvitationInvalid(RegistrationException):  # noqa N818
     def __init__(self):
         self.status_code = HTTPStatus.BAD_REQUEST

--- a/src/core/services/administrator_invitation.py
+++ b/src/core/services/administrator_invitation.py
@@ -14,7 +14,6 @@ from src.core.db.repository import (
 )
 from src.core.exceptions import (
     AdministratorAlreadyExistsException,
-    AdministratorNotFoundException,
     InvitationAlreadyActivated,
     InvitationAlreadyDeactivated,
 )
@@ -35,12 +34,8 @@ class AdministratorInvitationService:
         Аргументы:
             invitation_data (AdministratorMailRequestRequest): предзаполненные администратором данные
         """
-        try:
-            administrators = await self.__administrator_repository.get_by_email(invitation_data.email)
-            if administrators:
-                raise AdministratorAlreadyExistsException
-        except AdministratorNotFoundException:
-            pass
+        if await self.__administrator_repository.check_administrator_existence(invitation_data.email):
+            raise AdministratorAlreadyExistsException
         expiration_date = datetime.utcnow() + settings.INVITE_LINK_EXPIRATION_TIME
         return await self.__administrator_mail_request_repository.create(
             AdministratorInvitation(**invitation_data.dict(), expired_datetime=expiration_date)

--- a/src/core/services/administrator_invitation.py
+++ b/src/core/services/administrator_invitation.py
@@ -20,7 +20,6 @@ from src.core.exceptions import (
 )
 
 
-
 class AdministratorInvitationService:
     def __init__(
         self,


### PR DESCRIPTION
Задача: https://www.notion.so/Fix-administrators-160d62a3b15a4f0fa962e547970f3dec

- добавлена проверка, что email из приглашения отсутствует в модели administrators
- добавлено исключение для этого кейса

Возможно, в рамках задачи, стоит:
- использовать другой статус код для этого случая, но я увидел, что в подобных случаях используется 400, поэтому использовал его
- добавить проверку на отсутствие приглашения с таким же email, чтобы нельзя было дважды отправить email на один и тот же адрес - сейчас это возможно