### PR TITLE
Removed front volume from docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ volumes:
   postgres_data_stage:
   static_value:
   tasks:
-  frontend_volume:
 
 
 services:
@@ -41,7 +40,7 @@ services:
     image: ghcr.io/studio-yandex-practicum/lomaya_baryery_frontend:latest
     container_name: lomaya_baryery_frontend
     volumes:
-      - frontend_volume:/app/dist/
+      - ./frontend/:/app/result_build/
 
   swag:
     image: linuxserver/swag
@@ -66,6 +65,6 @@ services:
       - ./nginx/default.conf:/config/nginx/site-confs/default.conf
       - ./static/user_reports:/var/html/user_reports/
       - tasks:/var/html/tasks/
-      - frontend_volume:/var/html/frontend/
+      - ./frontend/:/var/html/frontend/
     env_file:
       - .env


### PR DESCRIPTION
При деплое фронта не менялись файлы в именованном волуме frontend_volume.
Удалил волум, сделал чтобы фронт мапился в папку в гостевой ОС. В таком виде все работает.