### PR TITLE
Fail2ban config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,6 +63,7 @@ services:
     volumes:
       - static_value:/var/html/static/
       - ./nginx/default.conf:/config/nginx/site-confs/default.conf
+      - ./fail2ban/jail.local:/config/fail2ban/jail.local
       - ./static/user_reports:/var/html/user_reports/
       - tasks:/var/html/tasks/
       - ./frontend/:/var/html/frontend/

--- a/fail2ban/jail.local
+++ b/fail2ban/jail.local
@@ -1,0 +1,46 @@
+[DEFAULT]
+ignoreip = 10.0.0.0/8
+           192.168.0.0/16
+           172.16.0.0/12
+
+banaction = iptables-allports
+
+bantime  = 30
+
+findtime  = 30
+
+maxretry = 5
+
+[ssh]
+enabled = false
+
+[nginx-http-auth]
+enabled  = true
+filter   = nginx-http-auth
+port     = http,https
+logpath  = /config/log/nginx/error.log
+
+[nginx-badbots]
+enabled  = true
+port     = http,https
+filter   = nginx-badbots
+logpath  = /config/log/nginx/access.log
+maxretry = 2
+
+[nginx-botsearch]
+enabled  = true
+port     = http,https
+filter   = nginx-botsearch
+logpath  = /config/log/nginx/access.log
+
+[nginx-deny]
+enabled  = true
+port     = http,https
+filter   = nginx-deny
+logpath  = /config/log/nginx/error.log
+
+[nginx-unauthorized]
+enabled  = false
+port     = http,https
+filter   = nginx-unauthorized
+logpath  = /config/log/nginx/access.log


### PR DESCRIPTION
Добавил конфиг для fail2ban.
По сути, это стандартный конфиг из свага, в котором отключен `nginx-unauthorized` и уменьшено время бана (с 600 до 30 сек).
