### PR TITLE
Feature(bot): inline-button for registrations

### DIFF
--- a/src/api/routers/administrator.py
+++ b/src/api/routers/administrator.py
@@ -166,6 +166,6 @@ class AdministratorCBV:
         current_admin = await self.authentication_service.get_current_active_administrator(token.credentials)
         if current_admin.role is not Administrator.Role.ADMINISTRATOR:
             raise AdministratorBlockError
-        elif current_admin.id == administrator_id:
+        if current_admin.id == administrator_id:
             raise AdministratorSelfBlockError
         return await self.administrator_service.block_administrator(administrator_id)

--- a/src/api/routers/administrator.py
+++ b/src/api/routers/administrator.py
@@ -16,11 +16,7 @@ from src.api.response_models.administrator import (
 )
 from src.api.response_models.error import generate_error_responses
 from src.core.db.models import Administrator
-from src.core.exceptions import (
-    AdministratorBlockError,
-    AdministratorSelfBlockError,
-    UnauthorizedException,
-)
+from src.core.exceptions import UnauthorizedException
 from src.core.services.administrator_service import AdministratorService
 from src.core.services.authentication_service import AuthenticationService
 
@@ -164,8 +160,4 @@ class AdministratorCBV:
     ) -> AdministratorResponse:
         """Заблокировать администратора."""
         current_admin = await self.authentication_service.get_current_active_administrator(token.credentials)
-        if current_admin.role is not Administrator.Role.ADMINISTRATOR:
-            raise AdministratorBlockError
-        if current_admin.id == administrator_id:
-            raise AdministratorSelfBlockError
-        return await self.administrator_service.block_administrator(administrator_id)
+        return await self.administrator_service.block_administrator(current_admin, administrator_id)

--- a/src/bot/main.py
+++ b/src/bot/main.py
@@ -6,6 +6,7 @@ from telegram.ext import (
     AIORateLimiter,
     Application,
     ApplicationBuilder,
+    CallbackQueryHandler,
     CommandHandler,
     MessageHandler,
     PicklePersistence,
@@ -17,6 +18,7 @@ from src.bot.handlers import (
     button_handler,
     incorrect_report_type_handler,
     photo_handler,
+    registration_button,
     start,
     web_app_data,
 )
@@ -45,6 +47,12 @@ def create_bot() -> Application:
     bot_instance.add_handler(CommandHandler("start", start))
     bot_instance.add_handler(MessageHandler(PHOTO, photo_handler))
     bot_instance.add_handler(MessageHandler(TEXT, button_handler))
+    bot_instance.add_handler(
+        CallbackQueryHandler(
+            callback=registration_button,
+            pattern="registration_button",
+        )
+    )
     bot_instance.add_handler(MessageHandler(StatusUpdate.WEB_APP_DATA, web_app_data))
     bot_instance.add_handler(MessageHandler(~HANDLED_MESSAGE_TYPES, incorrect_report_type_handler))
     bot_instance.job_queue.run_daily(

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -286,3 +286,15 @@ class AdministratorSelfChangeRoleError(ApplicationException):
     def __init__(self):
         self.status_code = HTTPStatus.FORBIDDEN
         self.detail = "Вы не можете изменить роль самому себе."
+
+
+class AdministratorBlockError(ApplicationException):
+    def __init__(self):
+        self.status_code = HTTPStatus.FORBIDDEN
+        self.detail = "У Вас нет прав на блокировку других администраторов."
+
+
+class AdministratorSelfBlockError(ApplicationException):
+    def __init__(self):
+        self.status_code = HTTPStatus.FORBIDDEN
+        self.detail = "Вы не можете заблокировать себя."

--- a/src/core/services/administrator_service.py
+++ b/src/core/services/administrator_service.py
@@ -59,3 +59,12 @@ class AdministratorService:
             administrator.role = Administrator.Role.ADMINISTRATOR
 
         return await self.__administrator_repository.update(administrator.id, administrator)
+
+    async def block_administrator(self, blocked_id: UUID) -> Administrator:
+        """Блокирует администратора."""
+        administrator = await self.__administrator_repository.get(blocked_id)
+        if administrator.status is Administrator.Status.ACTIVE:
+            administrator.status = Administrator.Status.BLOCKED
+        else:
+            administrator.status = Administrator.Status.ACTIVE
+        return await self.__administrator_repository.update(administrator.id, administrator)

--- a/src/core/services/administrator_service.py
+++ b/src/core/services/administrator_service.py
@@ -61,11 +61,10 @@ class AdministratorService:
         return await self.__administrator_repository.update(administrator.id, administrator)
 
     async def block_administrator(self, blocked_by: Administrator, blocked_id: UUID) -> Administrator:
-
         """Блокирует администратора."""
-        if blocks.role is not Administrator.Role.ADMINISTRATOR:
+        if blocked_by.role is not Administrator.Role.ADMINISTRATOR:
             raise exceptions.AdministratorBlockError
-        if blocks.id == blocked_id:
+        if blocked_by.id == blocked_id:
             raise exceptions.AdministratorSelfBlockError
 
         administrator = await self.__administrator_repository.get(blocked_id)

--- a/src/core/services/administrator_service.py
+++ b/src/core/services/administrator_service.py
@@ -60,7 +60,8 @@ class AdministratorService:
 
         return await self.__administrator_repository.update(administrator.id, administrator)
 
-    async def block_administrator(self, blocks: Administrator, blocked_id: UUID) -> Administrator:
+    async def block_administrator(self, blocked_by: Administrator, blocked_id: UUID) -> Administrator:
+
         """Блокирует администратора."""
         if blocks.role is not Administrator.Role.ADMINISTRATOR:
             raise exceptions.AdministratorBlockError

--- a/src/core/services/administrator_service.py
+++ b/src/core/services/administrator_service.py
@@ -60,8 +60,13 @@ class AdministratorService:
 
         return await self.__administrator_repository.update(administrator.id, administrator)
 
-    async def block_administrator(self, blocked_id: UUID) -> Administrator:
+    async def block_administrator(self, blocks: Administrator, blocked_id: UUID) -> Administrator:
         """Блокирует администратора."""
+        if blocks.role is not Administrator.Role.ADMINISTRATOR:
+            raise exceptions.AdministratorBlockError
+        if blocks.id == blocked_id:
+            raise exceptions.AdministratorSelfBlockError
+
         administrator = await self.__administrator_repository.get(blocked_id)
         if administrator.status is Administrator.Status.ACTIVE:
             administrator.status = Administrator.Status.BLOCKED


### PR DESCRIPTION
Added `InlineButton` to call registration process template.
Added a handler for `CallbackQuery` from `InlineButton` and returning to the `KeyboardButtom`.

https://www.notion.so/Bot-cae1343ec01d42a897219b42f3add7ae

Оставлял комментарий в задаче в notion, сюда скопирую:

Кнопка сейчас же остается в меню, пока не придет сообщение о регистрации на смену. 
Ее можно свернуть-развернуть, она не пропадает. 
С этой кнопкой меню не особо понял, что нужно сделать. Или нужно сделать кнопку-команду в `BotFather`?

С `InlineButton` проблемка вышла, с нее не отправишь данные с шаблона sendData не активна. 

> sendData(data) 
> Function
>> A method used to send data to the bot. When this method is called, a service message is sent to the bot containing the data data of the length up to 4096 bytes, and the Web App is closed. See the field web_app_data in the class Message.This method is only available for Web Apps launched via a Keyboard button.

Поэтому одни костыли получились.
Повторения кода что-то много вышло.