### PR TITLE
Fix text spaces and flake8 error PEP 257

### DIFF
--- a/src/bot/jobs.py
+++ b/src/bot/jobs.py
@@ -26,8 +26,8 @@ async def send_no_report_reminder_job(context: CallbackContext) -> None:
         bot_service.send_message(
             member.user,
             (
-                f"{member.user.name} {member.user.surname}, мы потеряли тебя!"
-                f"Задание все еще ждет тебя."
+                f"{member.user.name} {member.user.surname}, мы потеряли тебя! "
+                f"Задание все еще ждет тебя. "
                 f"Напоминаем, что за каждое выполненное задание ты получаешь виртуальные "
                 f"\"ломбарьерчики\", которые можешь обменять на призы и подарки!"
             ),
@@ -38,7 +38,7 @@ async def send_no_report_reminder_job(context: CallbackContext) -> None:
 
 
 async def send_daily_task_job(context: CallbackContext) -> None:
-    """Автоматически запускает смену и рассылает задания"""
+    """Автоматически запускает смену и рассылает задания."""
     shift_session = get_session()
     report_session = get_session()
     member_session = get_session()


### PR DESCRIPTION
Фикс текста по [задаче](https://www.notion.so/2a8fee5a455b40edab9e07e6b25309c1?p=bfc1b52d2f354d0a8c2dbd20d5c42dd6&pm=s), В процессе фикса обнаружено нарушение PEP 257 требуещего закрывать первую строку документации функции точкой в соседней функции, исправлено.