### PR TITLE
Fix bugs: ВР-127, ВР-128, BP-131 and /administrators/refresh endpoint

### DIFF
--- a/src/api/request_models/administrator.py
+++ b/src/api/request_models/administrator.py
@@ -2,6 +2,7 @@ from pydantic import EmailStr, Field, SecretStr, StrictStr, validator
 
 from src.api.request_models.request_base import RequestBase
 from src.api.request_models.validators import name_surname_validator
+from src.core.db.models import Administrator
 from src.core.settings import settings
 
 
@@ -49,3 +50,15 @@ class AdministratorPasswordResetRequest(RequestBase):
     """Схема для запроса восстановления пароля администратора или эксперта."""
 
     email: EmailStr
+
+
+class AdministratorRoleRequest(RequestBase):
+    """Схема для запроса на смену роли администратора."""
+
+    role: Administrator.Role
+
+
+class AdministratorStatusRequest(RequestBase):
+    """Схема для запроса на смену статуса администратора."""
+
+    status: Administrator.Status

--- a/src/api/routers/administrator.py
+++ b/src/api/routers/administrator.py
@@ -196,7 +196,7 @@ class AdministratorCBV:
         "/{administrator_id}/status/",
         response_model=AdministratorResponse,
         status_code=HTTPStatus.OK,
-        summary="Заблокировать администратора.",
+        summary="Изменить статус администратора.",
         responses=generate_error_responses(HTTPStatus.BAD_REQUEST, HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND),
     )
     async def change_administrator_status(

--- a/src/api/routers/administrator.py
+++ b/src/api/routers/administrator.py
@@ -123,7 +123,7 @@ class AdministratorCBV:
             status (Administrator.Status, optional): Требуемый статус администраторов. По-умолчанию None.
             role (Administrator.Role, optional): Требуемая роль администраторов. По-умолчанию None.
         """
-        await self.authentication_service.check_administrator_is_active_by_token(token.credentials)
+        await self.authentication_service.check_administrator_by_token(token, is_active=True)
         return await self.administrator_service.get_administrators_filter_by_role_and_status(status, role)
 
     @router.patch(
@@ -139,8 +139,8 @@ class AdministratorCBV:
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
         """Изменить роль администратора."""
-        current_admin_email = self.authentication_service.get_email_from_token(token.credentials)
-        return await self.administrator_service.switch_administrator_role(current_admin_email, administrator_id)
+        await self.authentication_service.check_administrator_by_token(token, is_active=True, is_admin=True)
+        return await self.administrator_service.switch_administrator_role(administrator_id, token.credentials)
 
     @router.patch(
         "/reset_password",
@@ -154,8 +154,8 @@ class AdministratorCBV:
         payload: AdministratorPasswordResetRequest,
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
-        current_admin_email = self.authentication_service.get_email_from_token(token.credentials)
-        return await self.administrator_service.restore_administrator_password(current_admin_email, payload.email)
+        await self.authentication_service.check_administrator_by_token(token, is_active=True, is_admin=True)
+        return await self.administrator_service.restore_administrator_password(payload.email)
 
     @router.patch(
         "/{administrator_id}/block",
@@ -170,5 +170,5 @@ class AdministratorCBV:
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
         """Изменить статус администратора."""
-        current_admin_email = self.authentication_service.get_email_from_token(token.credentials)
-        return await self.administrator_service.switch_administrator_status(current_admin_email, administrator_id)
+        await self.authentication_service.check_administrator_by_token(token, is_active=True, is_admin=True)
+        return await self.administrator_service.switch_administrator_status(administrator_id, token.credentials)

--- a/src/api/routers/administrator.py
+++ b/src/api/routers/administrator.py
@@ -172,20 +172,40 @@ class AdministratorCBV:
         return await self.administrator_service.update_administrator(administrator_id, schema)
 
     @router.patch(
-        "/{administrator_id}/change_role",
+        "/{administrator_id}/role/expert",
         response_model=AdministratorResponse,
         status_code=HTTPStatus.OK,
         summary="Изменить роль администратора.",
         responses=generate_error_responses(HTTPStatus.BAD_REQUEST, HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND),
     )
-    async def administrator_change_role(
+    async def make_administrator_expert(
         self,
         administrator_id: UUID,
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
         """Изменить роль администратора."""
-        await self.authentication_service.check_administrator_by_token(token, is_admin=True)
-        return await self.administrator_service.switch_administrator_role(administrator_id, token.credentials)
+        await self.authentication_service.check_administrator_by_token(token, Administrator.Role.ADMINISTRATOR)
+        return await self.administrator_service.change_administrator_role(
+            administrator_id, Administrator.Role.EXPERT, token.credentials
+        )
+
+    @router.patch(
+        "/{administrator_id}/role/administrator",
+        response_model=AdministratorResponse,
+        status_code=HTTPStatus.OK,
+        summary="Изменить роль администратора.",
+        responses=generate_error_responses(HTTPStatus.BAD_REQUEST, HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND),
+    )
+    async def make_administrator_admin(
+        self,
+        administrator_id: UUID,
+        token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
+    ) -> AdministratorResponse:
+        """Изменить роль администратора."""
+        await self.authentication_service.check_administrator_by_token(token, Administrator.Role.ADMINISTRATOR)
+        return await self.administrator_service.change_administrator_role(
+            administrator_id, Administrator.Role.ADMINISTRATOR, token.credentials
+        )
 
     @router.patch(
         "/reset_password",
@@ -199,14 +219,14 @@ class AdministratorCBV:
         payload: AdministratorPasswordResetRequest,
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
-        await self.authentication_service.check_administrator_by_token(token, is_admin=True)
+        await self.authentication_service.check_administrator_by_token(token, Administrator.Role.ADMINISTRATOR)
         return await self.administrator_service.restore_administrator_password(payload.email)
 
     @router.patch(
         "/{administrator_id}/block",
         response_model=AdministratorResponse,
         status_code=HTTPStatus.OK,
-        summary="Изменить статус администратора.",
+        summary="Заблокировать администратора.",
         responses=generate_error_responses(HTTPStatus.BAD_REQUEST, HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND),
     )
     async def administrator_blocking(
@@ -215,5 +235,25 @@ class AdministratorCBV:
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
         """Изменить статус администратора."""
-        await self.authentication_service.check_administrator_by_token(token, is_admin=True)
-        return await self.administrator_service.switch_administrator_status(administrator_id, token.credentials)
+        await self.authentication_service.check_administrator_by_token(token, Administrator.Role.ADMINISTRATOR)
+        return await self.administrator_service.change_administrator_status(
+            administrator_id, Administrator.Status.BLOCKED, token.credentials
+        )
+
+    @router.patch(
+        "/{administrator_id}/unblock",
+        response_model=AdministratorResponse,
+        status_code=HTTPStatus.OK,
+        summary="Разблокировать администратора.",
+        responses=generate_error_responses(HTTPStatus.BAD_REQUEST, HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND),
+    )
+    async def administrator_unblocking(
+        self,
+        administrator_id: UUID,
+        token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
+    ) -> AdministratorResponse:
+        """Изменить статус администратора."""
+        await self.authentication_service.check_administrator_by_token(token, Administrator.Role.ADMINISTRATOR)
+        return await self.administrator_service.change_administrator_status(
+            administrator_id, Administrator.Status.ACTIVE, token.credentials
+        )

--- a/src/api/routers/administrator.py
+++ b/src/api/routers/administrator.py
@@ -10,6 +10,8 @@ from src.api.request_models.administrator import (
     AdministratorAuthenticateRequest,
     AdministratorPasswordResetRequest,
     AdministratorRegistrationRequest,
+    AdministratorRoleRequest,
+    AdministratorStatusRequest,
     AdministratorUpdateNameAndSurnameRequest,
 )
 from src.api.response_models.administrator import (
@@ -172,39 +174,41 @@ class AdministratorCBV:
         return await self.administrator_service.update_administrator(administrator_id, schema)
 
     @router.patch(
-        "/{administrator_id}/role/expert",
+        "/{administrator_id}/role/",
         response_model=AdministratorResponse,
         status_code=HTTPStatus.OK,
         summary="Изменить роль администратора.",
         responses=generate_error_responses(HTTPStatus.BAD_REQUEST, HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND),
     )
-    async def make_administrator_expert(
+    async def change_administrator_role(
         self,
         administrator_id: UUID,
+        schema: AdministratorRoleRequest,
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
         """Изменить роль администратора."""
         await self.authentication_service.check_administrator_by_token(token, Administrator.Role.ADMINISTRATOR)
         return await self.administrator_service.change_administrator_role(
-            administrator_id, Administrator.Role.EXPERT, token.credentials
+            administrator_id, schema.role, token.credentials
         )
 
     @router.patch(
-        "/{administrator_id}/role/administrator",
+        "/{administrator_id}/status/",
         response_model=AdministratorResponse,
         status_code=HTTPStatus.OK,
-        summary="Изменить роль администратора.",
+        summary="Заблокировать администратора.",
         responses=generate_error_responses(HTTPStatus.BAD_REQUEST, HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND),
     )
-    async def make_administrator_admin(
+    async def change_administrator_status(
         self,
         administrator_id: UUID,
+        schema: AdministratorStatusRequest,
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
-        """Изменить роль администратора."""
+        """Изменить статус администратора."""
         await self.authentication_service.check_administrator_by_token(token, Administrator.Role.ADMINISTRATOR)
-        return await self.administrator_service.change_administrator_role(
-            administrator_id, Administrator.Role.ADMINISTRATOR, token.credentials
+        return await self.administrator_service.change_administrator_status(
+            administrator_id, schema.status, token.credentials
         )
 
     @router.patch(
@@ -221,39 +225,3 @@ class AdministratorCBV:
     ) -> AdministratorResponse:
         await self.authentication_service.check_administrator_by_token(token, Administrator.Role.ADMINISTRATOR)
         return await self.administrator_service.restore_administrator_password(payload.email)
-
-    @router.patch(
-        "/{administrator_id}/block",
-        response_model=AdministratorResponse,
-        status_code=HTTPStatus.OK,
-        summary="Заблокировать администратора.",
-        responses=generate_error_responses(HTTPStatus.BAD_REQUEST, HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND),
-    )
-    async def administrator_blocking(
-        self,
-        administrator_id: UUID,
-        token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
-    ) -> AdministratorResponse:
-        """Изменить статус администратора."""
-        await self.authentication_service.check_administrator_by_token(token, Administrator.Role.ADMINISTRATOR)
-        return await self.administrator_service.change_administrator_status(
-            administrator_id, Administrator.Status.BLOCKED, token.credentials
-        )
-
-    @router.patch(
-        "/{administrator_id}/unblock",
-        response_model=AdministratorResponse,
-        status_code=HTTPStatus.OK,
-        summary="Разблокировать администратора.",
-        responses=generate_error_responses(HTTPStatus.BAD_REQUEST, HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND),
-    )
-    async def administrator_unblocking(
-        self,
-        administrator_id: UUID,
-        token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
-    ) -> AdministratorResponse:
-        """Изменить статус администратора."""
-        await self.authentication_service.check_administrator_by_token(token, Administrator.Role.ADMINISTRATOR)
-        return await self.administrator_service.change_administrator_status(
-            administrator_id, Administrator.Status.ACTIVE, token.credentials
-        )

--- a/src/api/routers/administrator.py
+++ b/src/api/routers/administrator.py
@@ -152,15 +152,15 @@ class AdministratorCBV:
         response_model=AdministratorResponse,
         status_code=HTTPStatus.OK,
         summary="Сброс пароля администратора.",
-        responses=generate_error_responses(HTTPStatus.BAD_REQUEST, HTTPStatus.NOT_FOUND),
+        responses=generate_error_responses(HTTPStatus.BAD_REQUEST, HTTPStatus.NOT_FOUND, HTTPStatus.FORBIDDEN),
     )
     async def administrator_reset_password(
         self,
         payload: AdministratorPasswordResetRequest,
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
-        await self.authentication_service.get_current_active_administrator(token.credentials)
-        return await self.administrator_service.restore_administrator_password(payload.email)
+        current_admin = await self.authentication_service.get_current_active_administrator(token.credentials)
+        return await self.administrator_service.restore_administrator_password(current_admin, payload.email)
 
     @router.patch(
         "/{administrator_id}/block",

--- a/src/api/routers/administrator.py
+++ b/src/api/routers/administrator.py
@@ -123,7 +123,7 @@ class AdministratorCBV:
             status (Administrator.Status, optional): Требуемый статус администраторов. По-умолчанию None.
             role (Administrator.Role, optional): Требуемая роль администраторов. По-умолчанию None.
         """
-        await self.authentication_service.check_administrator_by_token(token, is_active=True)
+        await self.authentication_service.check_administrator_by_token(token)
         return await self.administrator_service.get_administrators_filter_by_role_and_status(status, role)
 
     @router.patch(
@@ -139,7 +139,7 @@ class AdministratorCBV:
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
         """Изменить роль администратора."""
-        await self.authentication_service.check_administrator_by_token(token, is_active=True, is_admin=True)
+        await self.authentication_service.check_administrator_by_token(token, is_admin=True)
         return await self.administrator_service.switch_administrator_role(administrator_id, token.credentials)
 
     @router.patch(
@@ -154,7 +154,7 @@ class AdministratorCBV:
         payload: AdministratorPasswordResetRequest,
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
-        await self.authentication_service.check_administrator_by_token(token, is_active=True, is_admin=True)
+        await self.authentication_service.check_administrator_by_token(token, is_admin=True)
         return await self.administrator_service.restore_administrator_password(payload.email)
 
     @router.patch(
@@ -170,5 +170,5 @@ class AdministratorCBV:
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
         """Изменить статус администратора."""
-        await self.authentication_service.check_administrator_by_token(token, is_active=True, is_admin=True)
+        await self.authentication_service.check_administrator_by_token(token, is_admin=True)
         return await self.administrator_service.switch_administrator_status(administrator_id, token.credentials)

--- a/src/api/routers/administrator.py
+++ b/src/api/routers/administrator.py
@@ -144,8 +144,9 @@ class AdministratorCBV:
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
         """Изменить роль администратора."""
-        current_admin = await self.authentication_service.get_current_active_administrator(token.credentials)
-        return await self.administrator_service.switch_administrator_role(current_admin, administrator_id)
+        return await self.administrator_service.switch_a_field_with_checks(
+            token.credentials, administrator_id, Administrator.Role
+        )
 
     @router.patch(
         "/reset_password",
@@ -159,14 +160,13 @@ class AdministratorCBV:
         payload: AdministratorPasswordResetRequest,
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
-        current_admin = await self.authentication_service.get_current_active_administrator(token.credentials)
-        return await self.administrator_service.restore_administrator_password(current_admin, payload.email)
+        return await self.administrator_service.restore_administrator_password(token.credentials, payload.email)
 
     @router.patch(
         "/{administrator_id}/block",
         response_model=AdministratorResponse,
         status_code=HTTPStatus.OK,
-        summary="Заблокировать администратора.",
+        summary="Изменить статус администратора.",
         responses=generate_error_responses(HTTPStatus.BAD_REQUEST, HTTPStatus.FORBIDDEN, HTTPStatus.NOT_FOUND),
     )
     async def administrator_blocking(
@@ -174,6 +174,7 @@ class AdministratorCBV:
         administrator_id: UUID,
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorResponse:
-        """Заблокировать администратора."""
-        current_admin = await self.authentication_service.get_current_active_administrator(token.credentials)
-        return await self.administrator_service.block_administrator(current_admin, administrator_id)
+        """Изменить статус администратора."""
+        return await self.administrator_service.switch_a_field_with_checks(
+            token.credentials, administrator_id, Administrator.Status
+        )

--- a/src/api/routers/administrator.py
+++ b/src/api/routers/administrator.py
@@ -62,13 +62,11 @@ class AdministratorCBV:
         self,
         response: Response,
         refresh_token: str | None = Cookie(default=None),
-        token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> AdministratorAndAccessTokenResponse:
         """Обновление access и refresh токенов при помощи refresh токена, получаемого из cookie.
 
         Вернуть access-токен и информацию об администраторе.
         """
-        await self.authentication_service.check_administrator_is_active_by_token(token.credentials)
         admin_and_token = await self.authentication_service.refresh(refresh_token)
         response.set_cookie(key="refresh_token", value=admin_and_token.refresh_token, httponly=True, samesite="strict")
         admin_and_token.administrator.access_token = admin_and_token.access_token

--- a/src/api/routers/administrator_invitation.py
+++ b/src/api/routers/administrator_invitation.py
@@ -14,6 +14,7 @@ from src.api.response_models.administrator_invitation import (
     AdministratorInvitationResponse,
 )
 from src.api.response_models.error import generate_error_responses
+from src.core.db.models import Administrator
 from src.core.email import EmailProvider
 from src.core.services.administrator_invitation import AdministratorInvitationService
 from src.core.services.authentication_service import AuthenticationService
@@ -94,7 +95,7 @@ class AdministratorInvitationCBV:
     async def deactivate_invitation(
         self, invitation_id: UUID, token: HTTPAuthorizationCredentials = Depends(HTTPBearer())
     ) -> Any:
-        await self.authentication_service.check_administrator_by_token(token, is_admin=True)
+        await self.authentication_service.check_administrator_by_token(token, Administrator.Role.ADMINISTRATOR)
         return await self.administrator_invitation_service.deactivate_invitation(invitation_id)
 
     @router.patch(
@@ -111,7 +112,7 @@ class AdministratorInvitationCBV:
     async def reactivate_invitation(
         self, invitation_id: UUID, token: HTTPAuthorizationCredentials = Depends(HTTPBearer())
     ) -> Any:
-        await self.authentication_service.check_administrator_by_token(token, is_admin=True)
+        await self.authentication_service.check_administrator_by_token(token, Administrator.Role.ADMINISTRATOR)
         invitation = await self.administrator_invitation_service.reactivate_invitation(invitation_id)
         url = urljoin(settings.APPLICATION_URL, f"/pwd_create/{invitation.token}")
         await self.email_provider.send_invitation_link(url, invitation.name, invitation.email)

--- a/src/api/routers/administrator_invitation.py
+++ b/src/api/routers/administrator_invitation.py
@@ -46,7 +46,7 @@ class AdministratorInvitationCBV:
         invitation_data: AdministratorInvitationRequest,
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> Any:
-        await self.authentication_service.check_administrator_by_token(token, is_active=True)
+        await self.authentication_service.check_administrator_by_token(token)
         invite = await self.administrator_invitation_service.create_mail_request(invitation_data)
         url = urljoin(settings.APPLICATION_URL, f"/pwd_create/{invite.token}")
         await self.email_provider.send_invitation_link(url, invite.name, invite.email)
@@ -63,7 +63,7 @@ class AdministratorInvitationCBV:
     async def get_all_invitations(
         self, token: HTTPAuthorizationCredentials = Depends(HTTPBearer())
     ) -> list[AdministratorInvitationResponse]:
-        await self.authentication_service.check_administrator_by_token(token, is_active=True)
+        await self.authentication_service.check_administrator_by_token(token)
         return await self.administrator_invitation_service.list_all_invitations()
 
     @router.get(
@@ -94,7 +94,7 @@ class AdministratorInvitationCBV:
     async def deactivate_invitation(
         self, invitation_id: UUID, token: HTTPAuthorizationCredentials = Depends(HTTPBearer())
     ) -> Any:
-        await self.authentication_service.check_administrator_by_token(token, is_active=True, is_admin=True)
+        await self.authentication_service.check_administrator_by_token(token, is_admin=True)
         return await self.administrator_invitation_service.deactivate_invitation(invitation_id)
 
     @router.patch(
@@ -111,7 +111,7 @@ class AdministratorInvitationCBV:
     async def reactivate_invitation(
         self, invitation_id: UUID, token: HTTPAuthorizationCredentials = Depends(HTTPBearer())
     ) -> Any:
-        await self.authentication_service.check_administrator_by_token(token, is_active=True, is_admin=True)
+        await self.authentication_service.check_administrator_by_token(token, is_admin=True)
         invitation = await self.administrator_invitation_service.reactivate_invitation(invitation_id)
         url = urljoin(settings.APPLICATION_URL, f"/pwd_create/{invitation.token}")
         await self.email_provider.send_invitation_link(url, invitation.name, invitation.email)

--- a/src/api/routers/administrator_invitation.py
+++ b/src/api/routers/administrator_invitation.py
@@ -46,7 +46,7 @@ class AdministratorInvitationCBV:
         invitation_data: AdministratorInvitationRequest,
         token: HTTPAuthorizationCredentials = Depends(HTTPBearer()),
     ) -> Any:
-        await self.authentication_service.get_current_active_administrator(token.credentials)
+        await self.authentication_service.check_administrator_by_token(token, is_active=True)
         invite = await self.administrator_invitation_service.create_mail_request(invitation_data)
         url = urljoin(settings.APPLICATION_URL, f"/pwd_create/{invite.token}")
         await self.email_provider.send_invitation_link(url, invite.name, invite.email)
@@ -63,7 +63,7 @@ class AdministratorInvitationCBV:
     async def get_all_invitations(
         self, token: HTTPAuthorizationCredentials = Depends(HTTPBearer())
     ) -> list[AdministratorInvitationResponse]:
-        await self.authentication_service.get_current_active_administrator(token.credentials)
+        await self.authentication_service.check_administrator_by_token(token, is_active=True)
         return await self.administrator_invitation_service.list_all_invitations()
 
     @router.get(
@@ -94,7 +94,7 @@ class AdministratorInvitationCBV:
     async def deactivate_invitation(
         self, invitation_id: UUID, token: HTTPAuthorizationCredentials = Depends(HTTPBearer())
     ) -> Any:
-        await self.authentication_service.get_current_active_administrator(token.credentials)
+        await self.authentication_service.check_administrator_by_token(token, is_active=True, is_admin=True)
         return await self.administrator_invitation_service.deactivate_invitation(invitation_id)
 
     @router.patch(
@@ -111,7 +111,7 @@ class AdministratorInvitationCBV:
     async def reactivate_invitation(
         self, invitation_id: UUID, token: HTTPAuthorizationCredentials = Depends(HTTPBearer())
     ) -> Any:
-        await self.authentication_service.get_current_active_administrator(token.credentials)
+        await self.authentication_service.check_administrator_by_token(token, is_active=True, is_admin=True)
         invitation = await self.administrator_invitation_service.reactivate_invitation(invitation_id)
         url = urljoin(settings.APPLICATION_URL, f"/pwd_create/{invitation.token}")
         await self.email_provider.send_invitation_link(url, invitation.name, invitation.email)

--- a/src/api/routers/report.py
+++ b/src/api/routers/report.py
@@ -46,7 +46,7 @@ class ReportsCBV:
         - **status**: статус задачи
         - **photo_url**: url фото выполненной задачи
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.report_service.get_report(report_id)
 
     @router.patch(
@@ -102,5 +102,5 @@ class ReportsCBV:
         - **shift_id**: уникальный id смены, ожидается в формате UUID.uuid4
         - **report.status**: статус задачи
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.report_service.get_summaries_of_reports(shift_id, status)

--- a/src/api/routers/request.py
+++ b/src/api/routers/request.py
@@ -35,7 +35,7 @@ class RequestCBV:
         request: Request,
     ) -> RequestResponse:
         """Одобрить заявку на участие в акции."""
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.request_service.approve_request(request_id, request.app.state.bot_instance)
 
     @router.patch(
@@ -52,7 +52,7 @@ class RequestCBV:
         decline_request_data: RequestDeclineRequest | None = Body(None),
     ) -> RequestResponse:
         """Отклонить заявку на участие в акции."""
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.request_service.decline_request(
             request_id, request.app.state.bot_instance, decline_request_data
         )
@@ -77,5 +77,5 @@ class RequestCBV:
         - **request_status**: статус заявки
         - **user_status**: статус участника
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.request_service.get_requests_list(status)

--- a/src/api/routers/shift.py
+++ b/src/api/routers/shift.py
@@ -51,7 +51,7 @@ class ShiftCBV:
         - **started_at**: дата начала смены
         - **finished_at**: дата окончания смены
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.shift_service.create_new_shift(shift)
 
     @router.get(
@@ -76,7 +76,7 @@ class ShiftCBV:
         - **started_at**: дата начала смены
         - **finished_at**: дата окончания смены
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.shift_service.get_shift(shift_id)
 
     @router.patch(
@@ -102,7 +102,7 @@ class ShiftCBV:
         - **title**: название смены
         - **final_message**: шаблон сообщения о завершении смены
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.shift_service.update_shift(request.app.state.bot_instance, shift_id, update_shift_data)
 
     @router.patch(
@@ -122,7 +122,7 @@ class ShiftCBV:
 
         - **shift_id**: уникальный идентификатор смены
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.shift_service.start_shift(shift_id)
 
     @router.get(
@@ -143,7 +143,7 @@ class ShiftCBV:
         - **shift**: Информация о смене
         - **members**: Список всех одобренных пользователей смены.
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.shift_service.get_shift_with_members(shift_id, member_status)
 
     @router.get(
@@ -174,7 +174,7 @@ class ShiftCBV:
         - **request_id**: Номер заявки
         - **status**: Статус заявки
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.shift_service.list_all_requests(_id=shift_id, status=status)
 
     @router.get(
@@ -200,7 +200,7 @@ class ShiftCBV:
         - **finished_at**: дата окончания смены
         - **total_users**: количество участников смены
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.shift_service.list_all_shifts(status, sort)
 
     @router.patch(
@@ -217,7 +217,7 @@ class ShiftCBV:
 
         - **shift_id**: уникальный идентификатор смены
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.shift_service.finish_shift(request.app.state.bot_instance, shift_id)
 
     @router.patch(
@@ -237,5 +237,5 @@ class ShiftCBV:
         - **shift_id**: уникальный идентификатор смены
         - **final_message**: сообщение об отмене смены
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.shift_service.cancel_shift(request.app.state.bot_instance, shift_id, cancel_shift_data)

--- a/src/api/routers/task.py
+++ b/src/api/routers/task.py
@@ -39,7 +39,7 @@ class TaskCBV:
         - **description**: описание задания в повелительном наклонении, например: "Убери со стола"
         - **description_for_message**: описание задания в совершенном виде, например: "Убрать со стола"
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.task_service.create_task(task)
 
     @router.get(
@@ -59,7 +59,7 @@ class TaskCBV:
         - **description**: описание задания в повелительном наклонении, например: "Убери со стола"
         - **description_for_message**: описание задания в совершенном виде, например: "Убрать со стола"
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.task_service.get_all_tasks()
 
     @router.get(
@@ -83,7 +83,7 @@ class TaskCBV:
         - **description**: описание задания в повелительном наклонении, например: "Убери со стола"
         - **description_for_message**: описание задания в совершенном виде, например: "Убрать со стола"
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.task_service.get_task(task_id)
 
     @router.patch(
@@ -107,7 +107,7 @@ class TaskCBV:
         - **description**: описание задания в повелительном наклонении, например: "Убери со стола"
         - **description_for_message**: описание задания в совершенном виде, например: "Убрать со стола"
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.task_service.update_task(task_id, update_task_data)
 
     @router.patch(

--- a/src/api/routers/user.py
+++ b/src/api/routers/user.py
@@ -49,7 +49,7 @@ class UserCBV:
         - **shifts_count**: количество пройденных пользователем смен
         - **is_in_active_shift**: флаг, является ли пользователь участником текущей активной смены
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.user_service.list_all_users(status, field_sort, direction_sort)
 
     @router.get(
@@ -73,5 +73,5 @@ class UserCBV:
         - **phone_number**: телефон пользователя
         - **shifts**: список смен пользователя
         """
-        await self.authentication_service.get_current_active_administrator(self.token.credentials)
+        await self.authentication_service.check_administrator_by_token(self.token)
         return await self.user_service.get_user_by_id_with_shifts_detail(user_id)

--- a/src/core/db/models.py
+++ b/src/core/db/models.py
@@ -1,6 +1,7 @@
 import enum
 import uuid
 from datetime import datetime
+from typing import Type
 
 from sqlalchemy import (
     DATE,
@@ -227,6 +228,27 @@ class Administrator(Base):
 
     def __repr__(self) -> str:
         return f"<Administrator: {self.name} {self.surname}, role: {self.role}>"
+
+    def switch_status(self):
+        if self.status is Administrator.Status.ACTIVE:
+            self.status = Administrator.Status.BLOCKED
+        else:
+            self.status = Administrator.Status.ACTIVE
+
+    def switch_role(self):
+        if self.role is Administrator.Role.ADMINISTRATOR:
+            self.role = Administrator.Role.EXPERT
+        else:
+            self.role = Administrator.Role.ADMINISTRATOR
+
+    def switch_a_field(self, field: Type[Status | Role]):
+        methods = {
+            self.Status: self.switch_status,
+            self.Role: self.switch_role,
+        }
+        method = methods.get(field, None)
+        if method is not None:
+            method()
 
 
 class Report(Base):

--- a/src/core/db/models.py
+++ b/src/core/db/models.py
@@ -1,7 +1,6 @@
 import enum
 import uuid
 from datetime import datetime
-from typing import Type
 
 from sqlalchemy import (
     DATE,
@@ -228,27 +227,6 @@ class Administrator(Base):
 
     def __repr__(self) -> str:
         return f"<Administrator: {self.name} {self.surname}, role: {self.role}>"
-
-    def switch_status(self):
-        if self.status is Administrator.Status.ACTIVE:
-            self.status = Administrator.Status.BLOCKED
-        else:
-            self.status = Administrator.Status.ACTIVE
-
-    def switch_role(self):
-        if self.role is Administrator.Role.ADMINISTRATOR:
-            self.role = Administrator.Role.EXPERT
-        else:
-            self.role = Administrator.Role.ADMINISTRATOR
-
-    def switch_a_field(self, field: Type[Status | Role]):
-        methods = {
-            self.Status: self.switch_status,
-            self.Role: self.switch_role,
-        }
-        method = methods.get(field, None)
-        if method is not None:
-            method()
 
 
 class Report(Base):

--- a/src/core/db/repository/administrator_repository.py
+++ b/src/core/db/repository/administrator_repository.py
@@ -26,7 +26,7 @@ class AdministratorRepository(AbstractRepository):
             raise exceptions.AdministratorNotFoundError
         return administrator
 
-    async def administrator_exists(
+    async def is_administrator_exists(
         self,
         email: str,
         role: Administrator.Role | None = None,

--- a/src/core/db/repository/administrator_repository.py
+++ b/src/core/db/repository/administrator_repository.py
@@ -40,6 +40,23 @@ class AdministratorRepository(AbstractRepository):
         )
         return administrator_exists.scalar()
 
+    async def administrator_is_active(self, email: str) -> bool:
+        """Проверяет существование активного администратора с ролью admin по email.
+
+        Args:
+            email (str) - email администратора.
+
+        Returns:
+            bool: True — если администратор есть в БД, False — если нет
+        """
+        stmt = select(
+            select(Administrator)
+            .where(and_(Administrator.email == email, Administrator.status == Administrator.Status.ACTIVE))
+            .exists()
+        )
+        administrator_exists = await self._session.execute(stmt)
+        return administrator_exists.scalar()
+
     async def administrator_is_active_and_is_admin(self, email: str) -> bool:
         """Проверяет существование активного администратора с ролью admin по email.
 

--- a/src/core/db/repository/administrator_repository.py
+++ b/src/core/db/repository/administrator_repository.py
@@ -29,14 +29,12 @@ class AdministratorRepository(AbstractRepository):
     async def administrator_exists(
         self,
         email: str,
-        status: Administrator.Status | None = None,
         role: Administrator.Role | None = None,
     ) -> bool:
         """Проверяет существование администратора в БД.
 
         Args:
             email (str): email администратора.
-            status (Administrator.Status): статус администратора; если None — то статус администратора не проверяется.
             role (Administrator.Role): роль администратора; если None — то роль администратора не проверяется.
 
         Returns:
@@ -44,10 +42,8 @@ class AdministratorRepository(AbstractRepository):
         """
         check_conditions = [
             Administrator.email == email,
+            Administrator.status == Administrator.Status.ACTIVE,
         ]
-
-        if status is not None:
-            check_conditions.append(Administrator.status == status)
 
         if role is not None:
             check_conditions.append(Administrator.role == role)

--- a/src/core/db/repository/administrator_repository.py
+++ b/src/core/db/repository/administrator_repository.py
@@ -40,18 +40,14 @@ class AdministratorRepository(AbstractRepository):
         Returns:
             bool: True — если администратор есть в БД, False — если нет
         """
-        check_conditions = [
-            Administrator.email == email,
-            Administrator.status == Administrator.Status.ACTIVE,
-        ]
+        statement = select(Administrator).filter_by(email=email)
 
         if role is not None:
-            check_conditions.append(Administrator.role == role)
+            statement = statement.filter_by(role=role)
 
-        stmt = select(select(Administrator).filter(*check_conditions).exists())
+        statement = select(statement.exists())
 
-        administrator_exists = await self._session.execute(stmt)
-        return administrator_exists.scalar()
+        return (await self._session.execute(statement)).scalar()
 
     async def get_administrators_filter_by_role_and_status(
         self, status: Administrator.Status | None, role: Administrator.Role | None

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -240,20 +240,8 @@ class InvitationAlreadyActivatedError(BadRequestError):
     detail = "Невозможно изменить состояние приглашения. Приглашение уже активно"
 
 
-class AdministratorChangeError(ForbiddenError):
-    detail = "У вас нет прав на изменение других администраторов."
-
-
 class AdministratorSelfChangeError(ForbiddenError):
     detail = "Вы не можете изменить самого себя."
-
-
-class AdministratorBlockError(ForbiddenError):
-    detail = "У Вас нет прав на блокировку других администраторов."
-
-
-class AdministratorRestPasswordError(ForbiddenError):
-    detail = "Вы не можете сбросить пароль другому пользователю"
 
 
 class AdministratorUnknownStatusError(BadRequestError):

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -28,6 +28,7 @@ class UnauthorizedError(ApplicationError):
 
 class ForbiddenError(ApplicationError):
     status_code: HTTPStatus = HTTPStatus.FORBIDDEN
+    detail = "У вас недостаточно прав для выполнения этой операции"
 
 
 class NotFoundError(ApplicationError):
@@ -242,16 +243,12 @@ class AdministratorChangeError(ForbiddenError):
     detail = "У вас нет прав на изменение других администраторов."
 
 
-class AdministratorSelfChangeRoleError(ForbiddenError):
-    detail = "Вы не можете изменить роль самому себе."
+class AdministratorSelfChangeError(ForbiddenError):
+    detail = "Вы не можете изменить самого себя."
 
 
 class AdministratorBlockError(ForbiddenError):
     detail = "У Вас нет прав на блокировку других администраторов."
-
-
-class AdministratorSelfBlockError(ForbiddenError):
-    detail = "Вы не можете заблокировать себя."
 
 
 class AdministratorRestPasswordError(ForbiddenError):

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from src.core.settings import settings
 
 if TYPE_CHECKING:
+    from src.core.db.models import Administrator
     from src.core.db.models import Base as DatabaseModel
     from src.core.db.models import Request, Shift
 
@@ -253,3 +254,13 @@ class AdministratorBlockError(ForbiddenError):
 
 class AdministratorRestPasswordError(ForbiddenError):
     detail = "Вы не можете сбросить пароль другому пользователю"
+
+
+class AdministratorUnknownStatusError(BadRequestError):
+    def __init__(self, status: Administrator.Status):
+        self.detail = "Неизвестный статус администратора: {}".format(status)
+
+
+class AdministratorUnknownRoleError(BadRequestError):
+    def __init__(self, role: Administrator.Role):
+        self.detail = "Неизвестный статус администратора: {}".format(role)

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -252,3 +252,7 @@ class AdministratorBlockError(ForbiddenError):
 
 class AdministratorSelfBlockError(ForbiddenError):
     detail = "Вы не можете заблокировать себя."
+
+
+class AdministratorRestPasswordError(ForbiddenError):
+    detail = "Вы не можете сбросить пароль другому пользователю"

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -248,10 +248,6 @@ class InvitationAlreadyActivatedError(BadRequestError):
     detail = "Невозможно изменить состояние приглашения. Приглашение уже активно"
 
 
-class AdministratorSelfChangeError(ForbiddenError):
-    detail = "Вы не можете изменить самого себя."
-
-
 class AdministratorUnknownStatusError(BadRequestError):
     def __init__(self, status: Administrator.Status):
         self.detail = "Неизвестный статус администратора: {}".format(status)
@@ -259,4 +255,12 @@ class AdministratorUnknownStatusError(BadRequestError):
 
 class AdministratorUnknownRoleError(BadRequestError):
     def __init__(self, role: Administrator.Role):
-        self.detail = "Неизвестный статус администратора: {}".format(role)
+        self.detail = "Неизвестная роль администратора: {}".format(role)
+
+
+class AdministratorSelfChangeRoleError(ForbiddenError):
+    detail = "Вы не можете изменить роль самому себе."
+
+
+class AdministratorSelfChangeStatusError(ForbiddenError):
+    detail = "Вы не можете изменить статус самому себе."

--- a/src/core/services/administrator_invitation.py
+++ b/src/core/services/administrator_invitation.py
@@ -29,7 +29,7 @@ class AdministratorInvitationService:
         Аргументы:
             invitation_data (AdministratorMailRequestRequest): предзаполненные администратором данные
         """
-        if await self.__administrator_repository.administrator_exists(invitation_data.email):
+        if await self.__administrator_repository.is_administrator_exists(invitation_data.email):
             raise exceptions.AdministratorAlreadyExistsError
         expiration_date = datetime.utcnow() + settings.INVITE_LINK_EXPIRATION_TIME
         return await self.__administrator_mail_request_repository.create(

--- a/src/core/services/administrator_invitation.py
+++ b/src/core/services/administrator_invitation.py
@@ -29,7 +29,7 @@ class AdministratorInvitationService:
         Аргументы:
             invitation_data (AdministratorMailRequestRequest): предзаполненные администратором данные
         """
-        if await self.__administrator_repository.check_administrator_existence(invitation_data.email):
+        if await self.__administrator_repository.administrator_exists(invitation_data.email):
             raise exceptions.AdministratorAlreadyExistsError
         expiration_date = datetime.utcnow() + settings.INVITE_LINK_EXPIRATION_TIME
         return await self.__administrator_mail_request_repository.create(

--- a/src/core/services/administrator_service.py
+++ b/src/core/services/administrator_service.py
@@ -79,8 +79,6 @@ class AdministratorService:
     async def change_administrator_status(
         self, administrator_id: UUID, status: Administrator.Status, changer_token: str
     ) -> Administrator:
-        if status not in Administrator.Status.__members__.values():
-            raise exceptions.AdministratorUnknownStatusError(status)
 
         administrator = await self.__administrator_repository.get(administrator_id)
 
@@ -96,8 +94,6 @@ class AdministratorService:
     async def change_administrator_role(
         self, administrator_id: UUID, role: Administrator.Role, changer_token: str
     ) -> Administrator:
-        if role not in Administrator.Role.__members__.values():
-            raise exceptions.AdministratorUnknownRoleError(role)
 
         administrator = await self.__administrator_repository.get(administrator_id)
 

--- a/src/core/services/administrator_service.py
+++ b/src/core/services/administrator_service.py
@@ -1,5 +1,6 @@
 import secrets
 import string
+from typing import Type
 from uuid import UUID
 
 from fastapi import Depends
@@ -18,16 +19,33 @@ class AdministratorService:
         self,
         administrator_repository: AdministratorRepository = Depends(),
         administrator_invitation_service: AdministratorInvitationService = Depends(),
+        authentication_service: AuthenticationService = Depends(),
         email: EmailProvider = Depends(),
     ):
         self.__administrator_repository = administrator_repository
         self.__administrator_invitation_service = administrator_invitation_service
+        self.__authentication_service = authentication_service
         self.__email = email
 
     def __create_new_password(self) -> str:
         """Создать новый пароль."""
         alphabet = string.ascii_lowercase + string.digits
         return ''.join(secrets.choice(alphabet) for _ in range(8))
+
+    async def check_administrator_is_admin_by_email(self, email: str) -> bool:
+        """Проверяет существование активного администратора с ролью admin по email.
+
+        Проверяет есть ли в базе администратор, не заблокирован ли он и
+        есть ли у него роль ADMINISTRATOR.
+        Если одно из условий не выполняется, выбрасывается исключение.
+        Если все условия выполняются — возвращает True.
+        """
+        administrator_exists = await self.__administrator_repository.administrator_is_active_and_is_admin(email)
+
+        if not administrator_exists:
+            raise exceptions.ForbiddenError
+
+        return True
 
     async def register_new_administrator(self, token: UUID, schema: AdministratorRegistrationRequest) -> Administrator:
         """Регистрация нового администратора."""
@@ -52,36 +70,20 @@ class AdministratorService:
         """Получает список администраторов, опционально отфильтрованых по роли и/или статусу."""
         return await self.__administrator_repository.get_administrators_filter_by_role_and_status(status, role)
 
-    async def switch_administrator_role(self, changed_by: Administrator, administrator_id: UUID) -> Administrator:
-        """Переключает роль администратора."""
-        if changed_by.role is not Administrator.Role.ADMINISTRATOR:
-            raise exceptions.AdministratorChangeError
-
-        # не надо менять роль самому себе
-        if administrator_id == changed_by.id:
-            raise exceptions.AdministratorSelfChangeRoleError
-
-        administrator = await self.__administrator_repository.get(administrator_id)
-
-        if administrator.role is Administrator.Role.ADMINISTRATOR:
-            administrator.role = Administrator.Role.EXPERT
-        else:
-            administrator.role = Administrator.Role.ADMINISTRATOR
-
-        return await self.__administrator_repository.update(administrator.id, administrator)
-
-    async def restore_administrator_password(self, changed_by: Administrator, email: str) -> Administrator:
+    async def restore_administrator_password(self, token: str, email: str) -> Administrator:
         """Сброс пароля администратора.
 
         Любой пользователь может сбросить пароль самому себе.
-        Сбрасывать пароль другим администратором может только  пользователь с ролью `Administrator.Role.ADMINISTRATOR`
+        Сбрасывать пароль другим администратором может только пользователь с ролью `Administrator.Role.ADMINISTRATOR`
         -Генерация нового пароля.
         -Хэширование нового пароля.
         -Сохранеине нового пароля в БД.
         -Отправка нового пароля на почту Администратору/Эксперту.
         """
-        if changed_by.role is not Administrator.Role.ADMINISTRATOR and changed_by.email != email:
-            raise exceptions.AdministratorRestPasswordError
+        changer_email = self.__authentication_service.get_email_from_token(token)
+
+        if changer_email != email:
+            await self.check_administrator_is_admin_by_email(changer_email)
 
         password = self.__create_new_password()
         administrator = await self.__set_new_password(password, email)
@@ -95,16 +97,18 @@ class AdministratorService:
         instance = Administrator(hashed_password=hashed_password)
         return await self.__administrator_repository.update(id=administrator.id, instance=instance)
 
-    async def block_administrator(self, blocked_by: Administrator, blocked_id: UUID) -> Administrator:
-        """Блокирует администратора."""
-        if blocked_by.role is not Administrator.Role.ADMINISTRATOR:
-            raise exceptions.AdministratorBlockError
-        if blocked_by.id == blocked_id:
-            raise exceptions.AdministratorSelfBlockError
+    async def switch_a_field_with_checks(
+        self, token: str, administrator_id: UUID, field: Type[Administrator.Status | Administrator.Role]
+    ) -> Administrator:
+        changer_email = self.__authentication_service.get_email_from_token(token)
 
-        administrator = await self.__administrator_repository.get(blocked_id)
-        if administrator.status is Administrator.Status.ACTIVE:
-            administrator.status = Administrator.Status.BLOCKED
-        else:
-            administrator.status = Administrator.Status.ACTIVE
+        await self.check_administrator_is_admin_by_email(changer_email)
+
+        administrator = await self.__administrator_repository.get(administrator_id)
+
+        if administrator.email == changer_email:
+            raise exceptions.AdministratorSelfChangeError
+
+        administrator.switch_a_field(field)
+
         return await self.__administrator_repository.update(administrator.id, administrator)

--- a/src/core/services/authentication_service.py
+++ b/src/core/services/authentication_service.py
@@ -80,18 +80,16 @@ class AuthenticationService:
     async def check_administrator_by_token(
         self,
         token: HTTPAuthorizationCredentials,
-        is_active: bool | None = None,
         is_admin: bool | None = None,
     ) -> None:
         """Проверяет существование администратора по token-у.
 
+        Администратор должен существовать, иметь статус ACTIVE, а также
+        удовлетворять проверке роли (указывается в аргументах).
         Если одно из условий не выполняется, выбрасывается исключение.
 
         Args:
             token (str): JWT token.
-            is_active (bool): True — проверяет, что администратор активный;
-                              False — проверяет, что администратор не активный;
-                              None — статус администратора не проверяется.
             is_admin (bool): True — администратор имеет роль ADMINISTRATOR;
                              False — администратор имеет роль EXPERT;
                              None — роль администратора не проверяется.
@@ -100,11 +98,6 @@ class AuthenticationService:
         email = self.get_email_from_token(token.credentials)
 
         check_conditions = {"email": email}
-
-        if is_active:
-            check_conditions.update({"status": Administrator.Status.ACTIVE})
-        elif is_active is not None:
-            check_conditions.update({"status": Administrator.Status.BLOCKED})
 
         if is_admin:
             check_conditions.update({"role": Administrator.Role.ADMINISTRATOR})


### PR DESCRIPTION
  - administrator role and status change endpoints now get values of role or status from the request body
  - request models `AdministratorRoleRequest` and `AdministratorStatusRequest` was added according to validate the status and role from the request body
  - method `check_administrator_existence` of the `AdministratorRepository` class was replaced by the `administrator_exists` with the `role` argument;
  - method `check_administrator_by_token` was added to the `AuthenticationService` class;
  - method `check_administrator_by_token` is used now instead of the `get_current_active_administrator` in the places where you need to check only;
  - in method `restore_administrator_password` of class `AdministratorService` additional check was added: you are not allowed to change the password if you don't have the `Administrator.Role.ADMINISTRATOR` role;
  - in methods `deactivate_invitation` and `reactivate_invitation` of class `AdministratorInvitationCBV` additional check was added: you are not allowed to do these actions if you don't have the `Administrator.Role.ADMINISTRATOR` role;
  - in method `refresh` of the `AdministratorCBV` class authorization was removed;
  - unnecessary exceptions were removed.  

Задачи в Notion: 
- [ВР-127](https://www.notion.so/127-0e9ac4f376254044abe278d2d5f1ace4)
- [ВР-128](https://www.notion.so/128-d3f6c10dabe84edf908d97704d38645e)
- [BP-131](https://www.notion.so/131-373ff7be88994e8d9b35da2e073696b4)
- [/administrators/refresh endpoint](https://www.notion.so/Fix-GET-administrators-refresh-660824ba402f4b29a5a0779789d52dab)