### PR TITLE
Fix/bp 135 ready for complete status for finishing shift

### DIFF
--- a/src/core/db/models.py
+++ b/src/core/db/models.py
@@ -78,6 +78,12 @@ class Shift(Base):
         self.status = Shift.Status.STARTED.value
         self.started_at = datetime.now().date()
 
+    async def ready_for_complete(self):
+        if self.status != Shift.Status.STARTED.value:
+            raise exceptions.ShiftReadyForCompleteError(self)
+        self.status = Shift.Status.READY_FOR_COMPLETE.value
+        self.finished_at = datetime.now().date()
+
     async def finish(self):
         if self.status != Shift.Status.STARTED.value:
             raise exceptions.ShiftFinishError(self)

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -116,6 +116,11 @@ class ShiftStartError(BadRequestError):
         self.detail = "Невозможно начать смену {!r}. Проверьте статус смены".format(shift)
 
 
+class ShiftReadyForCompleteError(BadRequestError):
+    def __init__(self, shift: Shift):
+        self.detail = "Невозможно перевести в статус 'завершающаяся' смену {!r}. Проверьте статус смены".format(shift)
+
+
 class ShiftFinishError(BadRequestError):
     def __init__(self, shift: Shift):
         self.detail = "Невозможно завершить смену {!r}. Проверьте статус смены".format(shift)

--- a/src/core/services/shift_service.py
+++ b/src/core/services/shift_service.py
@@ -213,9 +213,14 @@ class ShiftService:
 
     async def finish_shift(self, bot: Application, shift_id: UUID) -> Shift:
         shift = await self.__shift_repository.get_with_members(shift_id, Member.Status.ACTIVE)
-        await shift.finish()
-        await self.__shift_repository.update(shift_id, shift)
-        await self.__telegram_bot(bot).notify_that_shift_is_finished(shift)
+        shift.set_finished_at_date()
+        if await self.__shift_repository.is_unreviewed_report_exists(shift.id):
+            shift.prepare_to_finish()
+            await self.__notify_users_with_reviewed_reports(shift.id, bot)
+        else:
+            shift.finish()
+            await self.__telegram_bot(bot).notify_that_shift_is_finished(shift)
+        await self.__shift_repository.update(shift.id, shift)
         return shift
 
     async def get_shift_with_members(


### PR DESCRIPTION
https://www.notion.so/135-101cfb456255495ab6aa1ba5a1fff219

ВР-135 При принудительном завершении смены с наличием непроверенных отчетов, смене присваивается статус "Прошедшая", а не "Завершающаяся". И отчеты пропадают из вкладки "Ждут проверки”

старый ПР https://github.com/Studio-Yandex-Practicum/lomaya_baryery_backend/pull/333
