### PR TITLE
Db/del description, rename description for message in task model

### DIFF
--- a/src/api/request_models/task.py
+++ b/src/api/request_models/task.py
@@ -5,8 +5,7 @@ from src.api.request_models.request_base import RequestBase
 
 
 class TaskRequest(RequestBase):
-    description: str = Field(..., min_length=3, max_length=150)
-    description_for_message: str = Field(..., min_length=3, max_length=150)
+    title: str = Field(..., min_length=3, max_length=150)
 
 
 class TaskCreateRequest(TaskRequest):

--- a/src/api/response_models/report.py
+++ b/src/api/response_models/report.py
@@ -40,8 +40,7 @@ class ReportSummaryResponse(BaseModel):
     user_name: str
     user_surname: str
     task_id: UUID
-    task_description: str
-    task_description_for_message: str
+    task_title: str
     task_url: str
     photo_url: Optional[str]
 

--- a/src/api/response_models/task.py
+++ b/src/api/response_models/task.py
@@ -7,8 +7,7 @@ class TaskResponse(BaseModel):
 
     id: UUID
     url: str
-    description: str
-    description_for_message: str
+    title: str
     is_archived: bool
 
     class Config:

--- a/src/api/routers/task.py
+++ b/src/api/routers/task.py
@@ -36,8 +36,7 @@ class TaskCBV:
         Создать новое задание.
 
         - **url**: изображение задания
-        - **description**: описание задания в повелительном наклонении, например: "Убери со стола"
-        - **description_for_message**: описание задания в совершенном виде, например: "Убрать со стола"
+        - **title**: описание задания в совершенном виде, например: "Убрать со стола"
         """
         await self.authentication_service.get_current_active_administrator(self.token.credentials)
         return await self.task_service.create_task(task)
@@ -56,8 +55,7 @@ class TaskCBV:
 
         - **id**: id задания
         - **url**: url задания
-        - **description**: описание задания в повелительном наклонении, например: "Убери со стола"
-        - **description_for_message**: описание задания в совершенном виде, например: "Убрать со стола"
+        - **title**: описание задания в совершенном виде, например: "Убрать со стола"
         """
         await self.authentication_service.get_current_active_administrator(self.token.credentials)
         return await self.task_service.get_all_tasks()
@@ -80,8 +78,7 @@ class TaskCBV:
 
         - **id**: id задания
         - **url**: url задания
-        - **description**: описание задания в повелительном наклонении, например: "Убери со стола"
-        - **description_for_message**: описание задания в совершенном виде, например: "Убрать со стола"
+        - **title**: описание задания в совершенном виде, например: "Убрать со стола"
         """
         await self.authentication_service.get_current_active_administrator(self.token.credentials)
         return await self.task_service.get_task(task_id)
@@ -104,8 +101,7 @@ class TaskCBV:
         Обновить информацию о задании с указанным ID.
 
         - **url**: url задания
-        - **description**: описание задания в повелительном наклонении, например: "Убери со стола"
-        - **description_for_message**: описание задания в совершенном виде, например: "Убрать со стола"
+        - **title**: описание задания в совершенном виде, например: "Убрать со стола"
         """
         await self.authentication_service.get_current_active_administrator(self.token.credentials)
         return await self.task_service.update_task(task_id, update_task_data)

--- a/src/bot/jobs.py
+++ b/src/bot/jobs.py
@@ -60,7 +60,7 @@ async def send_daily_task_job(context: CallbackContext) -> None:
             task_photo,
             (
                 f"Привет, {member.user.name}!\n"
-                f"Сегодня твоим заданием будет {task.description_for_message}. "
+                f"Сегодня твоим заданием будет {task.title}. "
                 f"Не забудь сделать фотографию, как ты выполняешь задание, и отправить на проверку."
             ),
             DAILY_TASK_BUTTONS,

--- a/src/core/db/DTO_models.py
+++ b/src/core/db/DTO_models.py
@@ -1,4 +1,3 @@
-
 from dataclasses import dataclass
 from datetime import date, datetime
 from uuid import UUID
@@ -29,15 +28,13 @@ class FullReportDto:
     user_name: str
     user_surname: str
     task_id: UUID
-    task_description: str
-    task_description_for_message: str
+    task_title: str
     task_url: str
     photo_url: str
 
 
 @dataclass
 class TasksAnalyticReportDto:
-    description: str
     approved: int
     declined: int
     skipped: int

--- a/src/core/db/migrations/versions/2023-05-03_01.54.02_rename_and_delete_some_tasks_fields.py
+++ b/src/core/db/migrations/versions/2023-05-03_01.54.02_rename_and_delete_some_tasks_fields.py
@@ -1,0 +1,43 @@
+"""rename_and_delete_some_tasks_fields
+
+Revision ID: 5a1ecb2d17c4
+Revises: 2c304127881b
+Create Date: 2023-05-03 01:54:02.703700
+
+"""
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '5a1ecb2d17c4'
+down_revision = '2c304127881b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('tasks', 'description_for_message', new_column_name='title')
+    op.drop_constraint('tasks_description_for_message_key', 'tasks', type_='unique')
+    op.create_unique_constraint(None, 'tasks', ['title'])
+
+    op.drop_constraint('tasks_description_key', 'tasks', type_='unique')
+    op.drop_column('tasks', 'description')
+
+
+def downgrade():
+    op.alter_column('tasks', 'title', new_column_name='description_for_message')
+    op.add_column('tasks', sa.Column('description', sa.VARCHAR(length=150), autoincrement=False, nullable=True))
+    with open('tasks.json', 'r', encoding='UTF-8') as json_file:
+        for task in json.load(json_file):
+            description: str = task.get('description')
+            description_for_message: str = task.get('description_for_message', description.lower())
+            op.execute(
+                f"UPDATE tasks SET description = '{description}' "
+                f"WHERE description_for_message = '{description_for_message}'"
+            )
+    op.alter_column('tasks', 'description', nullable=False)
+    op.drop_constraint('tasks_title_key', 'tasks', type_='unique')
+    op.create_unique_constraint(None, 'tasks', ['description'])
+    op.create_unique_constraint(None, 'tasks', ['description_for_message'])

--- a/src/core/db/models.py
+++ b/src/core/db/models.py
@@ -97,13 +97,12 @@ class Task(Base):
     __tablename__ = "tasks"
 
     url = Column(String(length=150), unique=True, nullable=False)
-    description = Column(String(length=150), unique=True, nullable=False)
-    description_for_message = Column(String(length=150), unique=True, nullable=False)
+    title = Column(String(length=150), unique=True, nullable=False)
     is_archived = Column(Boolean, default=False, nullable=False)
     reports = relationship("Report", back_populates="task")
 
     def __repr__(self):
-        return f"<Task: {self.id}, description: {self.description}>"
+        return f"<Task: {self.id}, title: {self.title}>"
 
 
 class User(Base):

--- a/src/core/db/repository/report_repository.py
+++ b/src/core/db/repository/report_repository.py
@@ -50,8 +50,7 @@ class ReportRepository(AbstractRepository):
             User.name,
             User.surname,
             Report.task_id,
-            Task.description,
-            Task.description_for_message,
+            Task.title,
             Task.url,
             Report.report_url.label("photo_url"),
         )

--- a/src/core/db/repository/task_repository.py
+++ b/src/core/db/repository/task_repository.py
@@ -30,7 +30,7 @@ class TaskRepository(AbstractRepository):
         """
         stmt = (
             select(
-                Task.description,
+                Task.title,
                 func.count().filter(Report.status == Report.Status.APPROVED).label(Report.Status.APPROVED),
                 func.count().filter(Report.status == Report.Status.DECLINED).label(Report.Status.DECLINED),
                 func.count().filter(Report.status == Report.Status.SKIPPED).label(Report.Status.SKIPPED),

--- a/src/core/services/task_service.py
+++ b/src/core/services/task_service.py
@@ -33,8 +33,7 @@ class TaskService:
 
     async def create_task(self, new_task: TaskCreateRequest) -> Task:
         task = Task(
-            description=new_task.description,
-            description_for_message=new_task.description_for_message,
+            title=new_task.title,
         )
         task.url = await self.__download_file(new_task.image)
         return await self.__task_repository.create(instance=task)
@@ -47,8 +46,7 @@ class TaskService:
 
     async def update_task(self, task_id: UUID, update_task_data: TaskUpdateRequest) -> Task:
         task = await self.__task_repository.get(task_id)
-        task.description = update_task_data.description
-        task.description_for_message = update_task_data.description_for_message
+        task.title = update_task_data.title
         task.url = update_task_data.url
         return await self.__task_repository.update(task_id, task)
 


### PR DESCRIPTION
[DB: удаление поля description в модели Task](https://concrete-web-bad.notion.site/2a8fee5a455b40edab9e07e6b25309c1?p=4443585917044b3a816b3b1079c0e747&pm=s) Первый этап - удалил поле description модели Task и переименовал поле tasks_description_key в title. Провел рефакторинг участков кода в которых осуществлялось обращение к этим полям. Добавил соответствующую миграцию.