### PR TITLE
Fix date and time using in administrator invitation service

### DIFF
--- a/src/core/db/models.py
+++ b/src/core/db/models.py
@@ -22,7 +22,8 @@ from sqlalchemy.ext.declarative import as_declarative
 from sqlalchemy.orm import deferred, relationship
 from sqlalchemy.schema import ForeignKey
 
-from src.core import exceptions, settings
+from src.core import exceptions
+from src.core.settings import settings
 
 
 @as_declarative()

--- a/src/core/db/repository/administrator_invitation.py
+++ b/src/core/db/repository/administrator_invitation.py
@@ -20,7 +20,7 @@ class AdministratorInvitationRepository(AbstractRepository):
         statement = select(AdministratorInvitation).where(
             and_(
                 AdministratorInvitation.token == token,
-                AdministratorInvitation.expired_datetime > datetime.utcnow(),
+                AdministratorInvitation.expired_datetime > datetime.now(),
             )
         )
         result = (await self._session.scalars(statement)).first()

--- a/src/core/services/administrator_invitation.py
+++ b/src/core/services/administrator_invitation.py
@@ -32,7 +32,7 @@ class AdministratorInvitationService:
         """
         if await self.__administrator_repository.check_administrator_existence(invitation_data.email):
             raise exceptions.AdministratorAlreadyExistsError
-        expiration_date = datetime.utcnow() + settings.INVITE_LINK_EXPIRATION_TIME
+        expiration_date = datetime.now() + settings.INVITE_LINK_EXPIRATION_TIME
         return await self.__administrator_mail_request_repository.create(
             AdministratorInvitation(**invitation_data.dict(), expired_datetime=expiration_date)
         )
@@ -43,7 +43,7 @@ class AdministratorInvitationService:
     async def close_invitation(self, token: UUID) -> None:
         """Устанавливаем прошедшую дату в invitation.expired_datetime."""
         invitation = await self.__administrator_mail_request_repository.get_mail_request_by_token(token)
-        invitation.expired_datetime = datetime.utcnow() - settings.INVITE_LINK_EXPIRATION_TIME
+        invitation.expired_datetime = datetime.now() - settings.INVITE_LINK_EXPIRATION_TIME
         await self.__administrator_mail_request_repository.update(invitation.id, invitation)
 
     async def list_all_invitations(self) -> list[AdministratorInvitation]:
@@ -54,16 +54,16 @@ class AdministratorInvitationService:
 
     async def deactivate_invitation(self, invitation_id: UUID) -> AdministratorInvitation:
         invitation = await self.get_invitation_by_id(invitation_id)
-        if invitation.expired_datetime < datetime.utcnow():
+        if invitation.expired_datetime < datetime.now():
             raise exceptions.InvitationAlreadyDeactivatedError
-        invitation.expired_datetime = datetime.utcnow() - settings.INVITE_LINK_EXPIRATION_TIME
+        invitation.expired_datetime = datetime.now() - settings.INVITE_LINK_EXPIRATION_TIME
         await self.__administrator_mail_request_repository.update(invitation_id, invitation)
         return invitation
 
     async def reactivate_invitation(self, invitation_id: UUID) -> AdministratorInvitation:
         invitation = await self.get_invitation_by_id(invitation_id)
-        if invitation.expired_datetime > datetime.utcnow():
+        if invitation.expired_datetime > datetime.now():
             raise exceptions.InvitationAlreadyActivatedError
-        invitation.expired_datetime = datetime.utcnow() + settings.INVITE_LINK_EXPIRATION_TIME
+        invitation.expired_datetime = datetime.now() + settings.INVITE_LINK_EXPIRATION_TIME
         await self.__administrator_mail_request_repository.update(invitation_id, invitation)
         return invitation

--- a/src/core/services/administrator_invitation.py
+++ b/src/core/services/administrator_invitation.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import Depends
@@ -6,12 +6,13 @@ from fastapi import Depends
 from src.api.request_models.administrator_invitation import (
     AdministratorInvitationRequest,
 )
-from src.core import exceptions, settings
+from src.core import exceptions
 from src.core.db.models import AdministratorInvitation
 from src.core.db.repository import (
     AdministratorInvitationRepository,
     AdministratorRepository,
 )
+from src.core.settings import settings
 
 
 class AdministratorInvitationService:
@@ -42,7 +43,7 @@ class AdministratorInvitationService:
     async def close_invitation(self, token: UUID) -> None:
         """Устанавливаем прошедшую дату в invitation.expired_datetime."""
         invitation = await self.__administrator_mail_request_repository.get_mail_request_by_token(token)
-        invitation.expired_datetime = date.today() - timedelta(days=1)
+        invitation.expired_datetime = datetime.utcnow() - settings.INVITE_LINK_EXPIRATION_TIME
         await self.__administrator_mail_request_repository.update(invitation.id, invitation)
 
     async def list_all_invitations(self) -> list[AdministratorInvitation]:
@@ -53,15 +54,15 @@ class AdministratorInvitationService:
 
     async def deactivate_invitation(self, invitation_id: UUID) -> AdministratorInvitation:
         invitation = await self.get_invitation_by_id(invitation_id)
-        if invitation.expired_datetime < datetime.now():
+        if invitation.expired_datetime < datetime.utcnow():
             raise exceptions.InvitationAlreadyDeactivatedError
-        invitation.expired_datetime = datetime.now() - timedelta(days=1)
+        invitation.expired_datetime = datetime.utcnow() - settings.INVITE_LINK_EXPIRATION_TIME
         await self.__administrator_mail_request_repository.update(invitation_id, invitation)
         return invitation
 
     async def reactivate_invitation(self, invitation_id: UUID) -> AdministratorInvitation:
         invitation = await self.get_invitation_by_id(invitation_id)
-        if invitation.expired_datetime > datetime.now():
+        if invitation.expired_datetime > datetime.utcnow():
             raise exceptions.InvitationAlreadyActivatedError
         invitation.expired_datetime = datetime.utcnow() + settings.INVITE_LINK_EXPIRATION_TIME
         await self.__administrator_mail_request_repository.update(invitation_id, invitation)

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -63,6 +63,9 @@ class Settings(BaseSettings):
     LOG_COMPRESSION: str = "tar.gz"
     LOG_LEVEL: str = "WARNING"
 
+    NUMBER_ATTEMPTS_SUBMIT_REPORT: int = 3  # количество попыток для сдачи фотоотчета для одного задания
+    INVITE_LINK_EXPIRATION_TIME = timedelta(days=1)  # время существования ссылки для приглашения на регистрацию
+
     @property
     def database_url(self) -> str:
         """Получить ссылку для подключения к DB."""
@@ -132,6 +135,3 @@ def get_settings():
 
 
 settings = get_settings()
-
-NUMBER_ATTEMPTS_SUBMIT_REPORT: int = 3  # количество попыток для сдачи фотоотчета для одного задания
-INVITE_LINK_EXPIRATION_TIME = timedelta(days=1)  # время существования ссылки для приглашения на регистрацию


### PR DESCRIPTION
  - we are using the local time in the `repository/administrator_invitation` module
  - we are using the local time in the `services/administrator_invitation` module
  - got rid of magic numbers in the `services/administrator_invitation` module, using constant INVITE_LINK_EXPIRATION_TIME from settings instead
  - fixed `settings` module and import of `settings` in models and administrator invitation service.