### PR TITLE
Fix with using subqueryload

### DIFF
--- a/src/core/db/repository/member_repository.py
+++ b/src/core/db/repository/member_repository.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from fastapi import Depends
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import joinedload, selectinload, subqueryload
 
 from src.core.db.db import get_session
 from src.core.db.models import Member, Report, Shift, User
@@ -46,7 +46,7 @@ class MemberRepository(AbstractRepository):
                 Report.task_date >= func.current_date() - task_amount,
             )
             .join(Report)
-            .join(Member.user)
+            .options(subqueryload(Member.user))
             .group_by(Member)
             .having(func.count() >= task_amount)
         )


### PR DESCRIPTION
[Test: проверить правильность исключения участника из смены](https://concrete-web-bad.notion.site/2a8fee5a455b40edab9e07e6b25309c1?p=5efb9bf9bf714a6d9bd40e9226157d82&pm=s).
    Выяснил причину ошибки: `send_daily_task_job -> await member_service.exclude_lagging_members(context.application) ->`[await self.__telegram_bot(bot).notify_excluded_members(lagging_members)](https://github.com/Studio-Yandex-Practicum/lomaya_baryery_backend/blob/1b3433e1bf62abfa190f19b11cb2bfdd2ffa0f53/src/bot/services.py#LL125C1-L135C80)
    В строке `send_message_tasks = [self.send_message(member.user, text) for member in members]`
при обращении к полю `member.user` возникает ошибка `sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place?`. 
    Эта ошибка связана с тем, что в методе `MemberService` [exclude_lagging_members](https://github.com/Studio-Yandex-Practicum/lomaya_baryery_backend/blob/1b3433e1bf62abfa190f19b11cb2bfdd2ffa0f53/src/core/services/member_service.py#L21) при объявлении переменной `lagging_members` используется метод `MemberRepository` [get_members_for_excluding](https://github.com/Studio-Yandex-Practicum/lomaya_baryery_backend/blob/1b3433e1bf62abfa190f19b11cb2bfdd2ffa0f53/src/core/db/repository/member_repository.py#L39).
    Суть проблемы в том, что он джоинит `.join(Member.user)` ленивым методом, что не подходит для асинхронного кода. Я пробовал использовать [.options(joinedload(Member.user))](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#joined-eager-loading) похожего на Django метод select_related, но он создает псевдонимы для полей приджоиненой модели User, которые должны быть прописаны в атрибутах `.group_by(Member)` не разобрался, как именно.
    Поэтому использовал метод [.options(subqueryload(Member.user)](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#subquery-eager-loading)  с ним ошибка изчезла.
Но вроде бы, предпочтительней использовать джоин.