### PR TITLE
Fix check before create not_participated_reports

### DIFF
--- a/src/core/services/request_service.py
+++ b/src/core/services/request_service.py
@@ -11,7 +11,7 @@ from src.api.response_models.request import RequestResponse
 from src.bot import services
 from src.core import exceptions
 from src.core.db.DTO_models import RequestDTO
-from src.core.db.models import Member, Request, User
+from src.core.db.models import Member, Request, Shift, User
 from src.core.db.repository import MemberRepository, RequestRepository, UserRepository
 from src.core.services.report_service import ReportService
 from src.core.services.shift_service import ShiftService
@@ -54,7 +54,7 @@ class RequestService:
         member = Member(user_id=request.user_id, shift_id=request.shift_id)
         member = await self.__member_repository.create(member)
         shift = await self.__shift_service.get_shift(request.shift_id)
-        if shift.started_at < get_current_task_date():
+        if shift.status is Shift.Status.STARTED:
             await self.__report_service.create_not_participated_reports(member_id=member.id, shift=shift)
 
         first_task_date = shift.started_at


### PR DESCRIPTION
[ВР-136 Report_id не формируется для статуса отчета (report_status) not_participate.](https://www.notion.so/84c67936a71e4c6395674d859e5c5ae0?v=5e483915c9e041d48e6ea780c33a492d&p=c76a9bf9131d420c8f45bf666e27e727&pm=s)
Сейчас у пользователя, чью заявку одобрили после отправки первого задания, не формируется report_id со статусом not_participated. На фронте отображается пустая клетка.
Причина в том что в [методе approve_request ](https://github.com/Studio-Yandex-Practicum/lomaya_baryery_backend/blob/37fd4fc500c1964541a6c254ed6c0d5e99842954/src/core/services/request_service.py#L57) дата проверяется на большее значение, а должно быть больше или равно. Для упрощения, сделал условием проверку статуса смены на соответсвие 'STARTED'