### PR TITLE
task1_attempt1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ fill_db.log
 
 # Frontend build
 frontend/
+
+venv/

--- a/src/core/db/repository/administrator_invitation.py
+++ b/src/core/db/repository/administrator_invitation.py
@@ -3,12 +3,12 @@ from typing import Optional
 from uuid import UUID
 
 from fastapi import Depends
-from sqlalchemy import and_, select
+from sqlalchemy import and_, not_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core import exceptions
 from src.core.db.db import get_session
-from src.core.db.models import AdministratorInvitation
+from src.core.db.models import Administrator, AdministratorInvitation
 from src.core.db.repository import AbstractRepository
 
 
@@ -27,3 +27,10 @@ class AdministratorInvitationRepository(AbstractRepository):
         if result is None:
             raise exceptions.AdministratorInvitationInvalidError
         return result
+
+    async def get_all_invitations(self):
+        """Возвращает из БД список приглашений, email которых не состоят в списке администраторов."""
+        statement = select(AdministratorInvitation).where(
+            not_(AdministratorInvitation.email.in_(select(Administrator.email)))
+        )
+        return (await self._session.scalars(statement)).all()

--- a/src/core/services/administrator_invitation.py
+++ b/src/core/services/administrator_invitation.py
@@ -47,7 +47,7 @@ class AdministratorInvitationService:
         await self.__administrator_mail_request_repository.update(invitation.id, invitation)
 
     async def list_all_invitations(self) -> list[AdministratorInvitation]:
-        return await self.__administrator_mail_request_repository.get_all()
+        return await self.__administrator_mail_request_repository.get_all_invitations()
 
     async def get_invitation_by_id(self, invitation_id: UUID) -> AdministratorInvitation:
         return await self.__administrator_mail_request_repository.get(invitation_id)


### PR DESCRIPTION
Задача №1. Скрыть приглашения, по которым администратор зарегистрировался. Здесь всё проще. Не нужно делать новых эндпойнтов. Нужно убрать из результата эндпойнта GET /administrators/invitations все приглашения у которых адрес почтового ящика присутствует в таблице с администраторами. 
По поводу активных админов. На созвоне уточню, но здесь ошибка. Если отображать только активных администраторов, то мы не увидим заблокированных и не сможем их разблокировать. Т.е. эту часть не нужно делать.